### PR TITLE
Rewrite the stratified sampling to be much faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,5 +251,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
+# NiceGui upload folder
+uploads/

--- a/CONFIG.yaml
+++ b/CONFIG.yaml
@@ -1,5 +1,5 @@
 OPEN_VS_SEQ_SAMPLING_DATA:
-  filename: "TestRun/COMPLETED_MIDRC_Sequ_Example_5000_patient.tsv"
+  filename: "TestRun/MIDRC_Sequ_Example_5000_patient.tsv"
   dataset_column: "dataset"
   datasets:
     Open: 0.8
@@ -13,7 +13,7 @@ OPEN_VS_SEQ_SAMPLING_DATA:
       labels: ['0-17', "18-49", '50-64', '65+']
 
 5_FOLDS_AND_TEST_SAMPLING_DATA:
-  filename: "TestRun/COMPLETED_MIDRC_Sequ_Example_5000_patient.tsv"
+  filename: "TestRun/MIDRC_Sequ_Example_5000_patient.tsv"
   dataset_column: "dataset"
   datasets:
     Fold 1: 16

--- a/TestRun/MIDRC_Sequ_Example_5000_patient.tsv
+++ b/TestRun/MIDRC_Sequ_Example_5000_patient.tsv
@@ -1,0 +1,5001 @@
+age_at_index	covid19_positive	submitter_id	ethnicity	race	sex	modality	CR	CT	DX	MR
+27	Yes	514382-003725	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+84	Yes	514382-009410	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	514382-003862	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+69	Yes	514382-002783	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+37	Yes	514382-010268	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	No	419639-009420	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+88	No	10008204-ngVa0gZDgUCNfp4mgP4KJA	Not Hispanic or Latino	White	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+58	No	419639-001052	Not Hispanic or Latino	Native Hawaiian or other Pacific Islander	Female	DX	FALSE	FALSE	TRUE	FALSE
+40	No	514382-017271	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+55	No	514382-037034	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+44	No	10008204-UiL2EsyMzkCDZVU4ip3FQ	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+65	Yes	514382-001155	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+33	Yes	514382-013339	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+68	Yes	514382-008435	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+27	Yes	10003752-XOkcYq7CukiU3FYkNG5MQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+51	Yes	10003752-uEEJb4hyKEuZPJ7w3YiULw	Not Hispanic or Latino	Black or African American	Female	"CR, DX"	TRUE	FALSE	TRUE	FALSE
+26	Yes	514382-005770	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+78	Yes	10000364-760894	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+72	No	514382-037008	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	No	419639-003876	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+21	No	10003752-1d8hdPLd8kiiPAGEs7UZnw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+57	No	419639-001816	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	Yes	10008204-O0103BkZ3Uu7iZbyqD8Lw	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+68	Yes	514382-009439	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+57	No	419639-011610	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+77	No	419639-000053	Not Hispanic or Latino	Asian	Female	"DX, CT"	FALSE	TRUE	TRUE	FALSE
+46	No	514382-037637	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+68	No	419639-002617	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	Yes	10022779-bsTJPwI7UOXQJkIBSpv1A	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	514382-000737	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+75	Yes	10022779-IENitiM0iY2QvlihxEA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+38	No	10003752-WddkxCMgJkawlj2nz7AwXg	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+46	No	419639-003835	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	514382-001187	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+51	Yes	419639-011421	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+24	Yes	10022779-CbSmuHGo0U29Ldq0DsK9bw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+58	No	10008204-mQLujxkTkSicV6etJCFw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	No	514382-017516	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+82	Yes	514382-002096	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+79	Yes	10022779-T6ASC32TLU66KHFrSbdeXg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+72	No	419639-000298	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+55	No	419639-001084	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+35	No	10008204-t2Mw0n1GCkqEJwlVi1eiGw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+35	Yes	10000364-706246	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+64	Yes	514382-010303	Not Hispanic or Latino	American Indian or Alaska Native	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	No	10008204-3daI7yyXGUi4v46iFBN90g	Not Hispanic or Latino	Black or African American	Female	"CT, CR"	TRUE	TRUE	FALSE	FALSE
+50	No	10008204-dS3BdpVJ06YCpLcyyDaQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+52	Yes	514382-012339	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	514382-008679	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+39	No	10000364-1535803	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+85	Yes	10003752-VXhEI7XwkSauPkTg0diMA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+65	Yes	514382-007694	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+57	No	514382-014342	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+33	Yes	419639-004856	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	No	514382-034761	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+73	Yes	514382-009552	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	10000364-959462	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+890	Yes	514382-000221	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	No	419639-006715	Not Hispanic or Latino	Asian	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+58	No	514382-034756	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	No	419639-004744	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+27	Yes	10022779-PeU6RTvqGUyXoP4fX0d2Aw	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+60	Yes	514382-006132	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+890	No	514382-015914	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+64	Yes	10003752-AZScbZnHZESRuq4aqfEpg	Not Hispanic or Latino	White	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+43	Yes	10022779-QdNnMSnEEafzgESWP4ODQ	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+81	No	419639-001117	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	Yes	10022779-3xmB7pycbEmrlxJEruUYKA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+26	No	10000364-6441159	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+76	No	419639-004012	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	No	514382-037491	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+37	Yes	419639-012474	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+51	No	10003752-9zhk1ocOIEiit3I9s9A9Ew	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+42	Yes	419639-012438	Not Hispanic or Latino	Not Reported	Male	"DX,CT,CR"	TRUE	TRUE	TRUE	FALSE
+20	No	419639-003115	Hispanic or Latino	Not Reported	Female	"DX, CT"	FALSE	TRUE	TRUE	FALSE
+66	No	419639-005485	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	10003752-BtbNEIRVUEmKKJpAzN2vw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+53	No	10008204-AqyktlzWjkmTgNRZdVBnVA	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+48	Yes	514382-004258	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	10022779-TzfqyKXrF0igKtwb8mQgBg	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+21	No	10008204-654BBIjgEiyxW4VYa02g	Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+8	Yes	10000364-2068813	Not Hispanic or Latino	White	Female	MR	FALSE	FALSE	FALSE	TRUE
+63	No	514382-015340	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	514382-011235	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	514382-038198	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+77	No	419639-008689	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+74	Yes	514382-003375	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	No	10008204-3LMame6rs0WDBVFde48lPw	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+26	No	514382-014446	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	10022779-sNAMT3tCf0SU0QzTI63bBQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+26	No	10000364-1469718	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+42	No	514382-035977	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+89	Yes	514382-014300	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+71	Yes	514382-008567	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+58	Yes	10000364-1976547	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+73	Yes	10022779-kPQN69yW0UOwMxglxRdn9g	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+40	Yes	514382-011426	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+25	Yes	10022779-mR5HQEC5VkiJELhpameC9w	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+41	No	10003752-HAvsOh7FbEp0Y9hPjtBoQ	Not Hispanic or Latino	Black or African American	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+82	No	10008204-4QVsshf3wEKAGzVbnMgGzg	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+58	Yes	514382-014024	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+48	No	514382-015895	Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+62	Yes	419639-011270	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	No	419639-004107	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	No	514382-036712	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+79	No	514382-040903	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+31	Yes	514382-007086	Not Hispanic or Latino	White	Male	"CR,CT,DX"	TRUE	TRUE	TRUE	FALSE
+69	Yes	10000364-1650670	Not Hispanic or Latino	White	Male	MR	FALSE	FALSE	FALSE	TRUE
+57	Yes	514382-000834	Not Reported	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+80	Yes	514382-006247	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+85	Yes	514382-000731	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+21	Yes	419639-012125	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	514382-013052	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+62	Yes	10022779-vvHDj0Nj1U6AEhQZYX0Kkg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+44	Yes	10003752-9I92CTMxpUiLrdkObztfxg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+55	No	419639-004402	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+50	No	514382-014977	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+36	No	419639-008195	Not Hispanic or Latino	Not Reported	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+44	Yes	10003752-x69AmJg2XEaAtka8WNqwjA	Not Hispanic or Latino	Black or African American	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+63	Yes	10000364-748349	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+81	Yes	514382-000844	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+69	No	419639-011158	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	10000364-5764867	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+46	Yes	10022779-WXoGhyJ1X0KIqUIRS5S6vQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+15	No	514382-017881	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	No	10008204-VcsDFc8dS0Sl5D6DqdwDxw	Not Hispanic or Latino	White	Male	"CT,CR,DX"	TRUE	TRUE	TRUE	FALSE
+70	Yes	514382-013193	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	No	10008204-GbkCidIO6EjNd7BH4st9Q	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+49	Yes	514382-009444	Not Hispanic or Latino	White	Female	"CR,CT,DX"	TRUE	TRUE	TRUE	FALSE
+52	No	514382-015216	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+16	Yes	10000364-5227965	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	No	419639-003590	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+78	Yes	10000364-655901	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+53	No	514382-041376	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	514382-039936	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+81	Yes	514382-008026	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+82	No	10008204-bGFLTWRda0erTgz3aj0DKQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+38	No	514382-037080	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	10000364-1520468	Not Hispanic or Latino	Black or African American	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+77	Yes	514382-003977	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	10022779-VJPaS6HuSkKBoCN4JeeQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+38	No	514382-036110	Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+75	No	10000364-726688	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+49	Yes	514382-000883	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+35	No	419639-001807	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+27	No	419639-003240	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+35	Yes	514382-003515	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	No	514382-017899	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	514382-009520	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+57	No	10000364-90761	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+43	Yes	10000364-5433313	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+77	Yes	514382-005903	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+41	Yes	10003752-L1HTuekFj0arHBpae5F5iQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+79	Yes	10000364-1279214	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+75	Yes	10003752-cmNpkL7gVUKINfB00XIA	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+34	Yes	514382-008509	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+59	No	10022779-gXlvoYXhk6UxOPBmKaYA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+65	Yes	10000364-1917172	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+28	Yes	514382-008861	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+45	No	10003752-Wch3tuIKfkadANDbT2AqGQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	Yes	10022779-wIFC3pSqP0ZkoKrZB0wjg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+51	Yes	514382-009821	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+77	No	419639-006737	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+30	No	514382-016962	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+84	Yes	514382-005632	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	No	419639-008886	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+23	No	10003752-4efN0KF5cUuMyrB6KvlwRQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+44	No	10003752-Q5d2zzCLXEWNtnL0HrvGA	Not Hispanic or Latino	Black or African American	Male	"CT,DX,CR"	TRUE	TRUE	TRUE	FALSE
+65	No	10000364-538607	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+77	Yes	514382-007638	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+62	No	514382-040109	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+34	No	419639-000950	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+63	Yes	10000364-6161583	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	No	10000364-27504	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+73	Yes	514382-008594	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+890	Yes	514382-008677	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+77	No	514382-017365	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+15	No	10003752-g3DGlHzSkOTFEGWN1lZfg	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+46	No	419639-009416	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+39	No	419639-005136	Not Hispanic or Latino	Asian	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+36	No	419639-008500	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	514382-009385	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+64	No	10000364-1355925	Not Hispanic or Latino	White	Female	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+64	No	419639-000322	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+44	Yes	10022779-rFGf5If560ygGlfiJC6Q	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-014728	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+34	No	514382-017077	Not Reported	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	No	419639-003478	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+89	Yes	10000364-5833699	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	No	10000364-726681	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+34	Yes	514382-004885	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	10022779-A8Y2yQvdVESOmYoqKtBbnw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+74	No	514382-041235	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	514382-006005	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	No	514382-035150	Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	No	10008204-qeRymORTUaySqAH1ry8PQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+17	Yes	10000364-1646166	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	No	10008204-awKfqtwkk0i34Tu67DB0AA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+4	No	10000364-6104586	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	Yes	514382-004565	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+73	No	514382-018239	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	No	419639-012584	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+85	No	514382-041451	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+21	Yes	10022779-JvvYXlU9jkqSOVVx6WQyiQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+90	No	419639-009573	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	10022779-f7YJDaBmSki2H82CfBZteA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	No	419639-009518	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	514382-008049	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+34	Yes	514382-009201	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+30	Yes	419639-009247	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	No	419639-004431	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+87	Yes	10000364-1551662	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+24	Yes	10022779-uEd7aNpwBU6G6B97Hkol6w	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	No	10008204-qWLsIzJBREef4nHCrtxzAw	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+48	No	419639-000463	Not Hispanic or Latino	Other	Female	CR	TRUE	FALSE	FALSE	FALSE
+43	No	514382-035724	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	Yes	514382-014280	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	10003752-l5nC19V3E2OAr5y0PtDGQ	Not Hispanic or Latino	Black or African American	Male	"CR, CT"	TRUE	TRUE	FALSE	FALSE
+47	Yes	10003752-dA8f1Mm0OmWAGY2IptaA	Not Hispanic or Latino	Asian	Male	CT	FALSE	TRUE	FALSE	FALSE
+65	Yes	514382-007913	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	No	419639-008032	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+24	Yes	514382-004165	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+30	No	514382-035806	Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	10003752-uBuJxADsM0yiAhCYgUUHw	Not Hispanic or Latino	Black or African American	Male	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+77	No	10008204-OLK68JKe6Uun0x5UxKs6iQ	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+75	No	10008204-ZFJSK7Lg3UOjpVtKlAhZg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+32	Yes	419639-012110	Not Hispanic or Latino	American Indian or Alaska Native	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	Yes	514382-011109	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+18	No	10008204-MnPrqGr4IUSGOhS9RFKcg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	No	419639-006075	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+58	Yes	10000364-5369984	Not Hispanic or Latino	Black or African American	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+35	Yes	514382-000835	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	10003752-r79KZeV1k6d3Vj9TAoKJA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+53	No	10008204-4871emkUJki3A073hxMSew	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+63	No	514382-037543	Not Hispanic or Latino	American Indian or Alaska Native	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	419639-007420	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	No	10022779-qjRjhwxZCUKGKnOHIfl8A	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+74	Yes	10008204-Au9IYRdZ010phDGxHZg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+80	Yes	10000364-755870	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+85	No	419639-006932	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	10003752-p3mNUtHBUWIA2MPYA47Q	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+63	No	419639-008508	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+75	No	514382-035211	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+47	No	419639-003731	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+35	No	514382-037182	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	10000364-247208	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+57	No	419639-005078	Hispanic or Latino	Not Reported	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+75	Yes	10000364-6335026	Hispanic or Latino	Not Reported	Female	CT	FALSE	TRUE	FALSE	FALSE
+88	No	419639-009388	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+50	Yes	419639-003777	Hispanic or Latino	Not Reported	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+48	No	514382-037454	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+54	Yes	10003752-VKOHt5LD6Um2A6rqhHoGeA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+26	No	10008204-j1YeIZuHG0amEJlQQPYg	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+59	Yes	10000364-5868569	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+52	No	419639-000861	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+47	No	514382-017787	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+33	Yes	514382-014190	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	Yes	10000364-917966	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+65	No	10000364-1803525	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	No	419639-009270	Not Hispanic or Latino	Other	Male	CR	TRUE	FALSE	FALSE	FALSE
+28	Yes	10000364-1425675	Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+40	Yes	514382-003430	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	514382-036197	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+34	No	514382-037171	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+84	No	514382-038537	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	419639-011520	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	10008204-13MzxeiNI0iiFK4J6bz7ow	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+88	No	10008204-o6JIqVG9eE6v9grzOuwsSQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+59	No	419639-010692	Not Hispanic or Latino	White	Male	"DX, CT"	FALSE	TRUE	TRUE	FALSE
+45	Yes	514382-008924	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	No	419639-010634	Not Hispanic or Latino	Not Reported	Male	"DX, CT"	FALSE	TRUE	TRUE	FALSE
+69	No	419639-007536	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	419639-007532	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+72	No	10000364-6411812	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+19	No	419639-012495	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+39	No	10003752-rabx46DJwEGDtrpYfdvVkg	Hispanic or Latino	White	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+90	No	419639-011727	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	No	514382-035946	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	514382-000229	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+80	No	419639-011872	Not Hispanic or Latino	Not Reported	Female	CT	FALSE	TRUE	FALSE	FALSE
+35	Yes	10003752-40B7apQKxUSE6A36F5529Q	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-040041	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+64	No	419639-001299	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+65	Yes	10008204-tNrRG6wLmE2YD6zgv45dcA	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+45	Yes	419639-011951	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+37	No	514382-036462	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+48	Yes	10000364-2038711	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+52	Yes	514382-005758	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+80	Yes	514382-007841	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	514382-002459	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+46	Yes	10000364-1308159	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	No	10008204-Q2q5kvwdyUCUO8NryjlLA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+83	No	10008204-Wo7Nefis000TAydSPuF1w	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	No	514382-039318	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	419639-012483	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+38	No	10000364-6105979	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+74	No	419639-009252	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+72	No	10000364-5976966	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+25	No	514382-018103	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+40	No	10000364-411634	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+40	Yes	10000364-1516335	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+20	Yes	514382-004788	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+46	No	10000364-1199289	Not Hispanic or Latino	Black or African American	Male	"CR, DX"	TRUE	FALSE	TRUE	FALSE
+89	Yes	514382-004172	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+68	No	10008204-a3WFT3Td7kWCoyQthe8x1A	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+83	No	10008204-pJCKafRkiknpRkykn6yA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	10022779-aVEKmLlpI0CozTQw6ybF7g	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	No	419639-005048	Not Hispanic or Latino	Black or African American	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+83	No	10008204-LWYS463k6lX0eXDBw0KQ	Not Hispanic or Latino	White	Female	"CT, CR"	TRUE	TRUE	FALSE	FALSE
+49	No	10022779-ggrHR0dkk6AqmWU52mQaQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+47	Yes	514382-013640	Hispanic or Latino	Other	Female	CT	FALSE	TRUE	FALSE	FALSE
+53	No	419639-008772	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+28	No	10008204-FdRvkraHMUmfcKa28BIJvA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+36	No	419639-007940	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+84	No	10000364-6043425	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+36	No	514382-034883	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+49	No	10000364-1263635	Not Hispanic or Latino	Black or African American	Female	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+890	Yes	10008204-Uf9YsII0NEiv8KxWMHb1A	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+43	No	419639-003865	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+27	Yes	10003752-95gFVQNQC0GV6VQ80LgCg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+890	Yes	514382-001410	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+46	No	10008204-OS3OiacedkuSOe7JU4IhGg	Not Hispanic or Latino	Asian	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+56	No	419639-005888	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	No	419639-001680	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+17	No	10008204-prOumLvDlUCk2NVGLgfL5Q	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+59	No	10022779-q0M3hjNBd0OdXG508SxDFw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+14	No	10000364-1209345	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+71	No	10008204-1P9Gn3d000eautWLOoH3Uw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+78	No	514382-014902	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	10000364-121748	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+80	No	419639-011638	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+35	No	419639-001655	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	No	514382-037986	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+16	No	10000364-1752078	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+50	Yes	514382-005436	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+87	Yes	10000364-1605907	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+68	No	10008204-StckxqGirUKtk978rN0C1g	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+33	No	10000364-6603922	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+890	No	10008204-0m3IrhdjEiGsMF7YCHybw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+2	No	10000364-6202975	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	No	10008204-D7FXZBOB50qpdjq9HgsuTg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+45	No	514382-016335	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+39	No	419639-005599	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+41	Yes	10000364-5543671	Not Hispanic or Latino	Black or African American	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+57	No	10008204-jH2XQMs3Xk2628GMsc4A	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+89	No	419639-001939	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+51	No	419639-004634	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+81	No	10008204-1p7Frcw6nUXnLILQgtMDQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+28	Yes	514382-002962	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+62	Yes	10022779-Sux7G2ykKCeLbQ18KxEw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+47	Yes	514382-010739	Not Hispanic or Latino	Asian	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+58	No	514382-014432	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+51	No	10000364-5670835	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+27	No	10000364-2613987	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+60	Yes	10000364-1416442	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+54	Yes	514382-001284	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+39	Yes	10000364-6544460	Hispanic or Latino	Not Reported	Female	CT	FALSE	TRUE	FALSE	FALSE
+56	No	10000364-2450037	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+50	Yes	10000364-354467	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+75	No	10000364-1941048	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	No	419639-007517	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+62	Yes	10000364-1532359	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+54	No	419639-011436	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+39	No	514382-036366	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+34	Yes	514382-008586	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	No	419639-000934	Not Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+58	No	10008204-qI7VaIvExUa0fApENvi8Dw	Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+66	No	10008204-zMGPs6qIUSKGM0fFjti8A	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	10022779-eqNYIwVDAEa7FdRAhXyV2w	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+71	Yes	514382-008132	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	No	10000364-1465750	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+32	Yes	10022779-AixIZy13PUCr4jhGygFw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+21	Yes	514382-003628	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+3	Yes	10000364-6175968	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	No	514382-040337	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	10022779-PBMpRU0IUqqE4bzh8mHvQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+55	No	10000364-5828290	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	10022779-1FAMzMnDkKp8zRHkOjSuA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	No	10008204-1d7Yn9nh8kOxO0GHhiOQQ	Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+32	No	10008204-7bSxjMDSqkyuvMU2imYdQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+86	No	419639-007811	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	No	10000364-1908129	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+62	Yes	514382-006748	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+72	No	514382-038875	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	No	10008204-KAWQD0l6a0q5VmpS8pfmUQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+41	No	419639-002102	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	10000364-5802663	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+58	Yes	419639-011863	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+79	Yes	514382-006183	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+64	Yes	10003752-jgeE1nXU90itNUQ2xOSAxQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+57	Yes	10000364-2617430	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-017001	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+73	No	10008204-LOCiLitwIEmJOf7jiGkXMA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+57	No	419639-002500	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+12	No	10003752-lW29yHHd0kuAdEEgQUMEyQ	Hispanic or Latino	Not Reported	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+52	No	514382-039482	Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+88	No	10008204-WMzqwmtkv0KKg1uVH35MpA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+890	Yes	514382-010019	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	No	10003752-PS8kSEdjN0OIc9fQtMC12w	Not Hispanic or Latino	Native Hawaiian or other Pacific Islander	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+80	No	10003752-i2s1ibXSEmBIpQx9RJkHA	Not Reported	White	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+66	No	419639-004022	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	No	514382-038827	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+48	Yes	10000364-1516198	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+64	Yes	10022779-9zTW8bnwoUSnULGRXFoocg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+63	Yes	10022779-5mNyi56JX0io0D0s7ZEYg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+41	Yes	10000364-386537	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+6	No	10003752-nVUaSPoVgESBdwLtTrO0A	Not Hispanic or Latino	Black or African American	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+65	Yes	514382-005652	Not Reported	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+39	No	419639-004508	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+69	No	10000364-497173	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+20	Yes	514382-001337	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	Yes	10003752-3ehDbw67KEKeCYx0O3wOA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+89	No	514382-034639	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+90	Yes	10000364-802767	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+83	Yes	10008204-gdYfNYCEj003tGCuhd1MQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+52	Yes	10003752-hnaSdNbnp0eIjumJj0WelA	Not Reported	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+89	No	419639-009907	Not Hispanic or Latino	White	Male	"DX, CT, CR"	TRUE	TRUE	TRUE	FALSE
+52	No	514382-036451	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	No	10022779-iNWwZj9e2ECFpBcyVfiAA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+30	No	419639-000477	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+57	Yes	10003752-Fqei6mBECmAastTrTLlg	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+30	Yes	514382-003342	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+78	Yes	419639-010963	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+37	Yes	419639-007258	Not Hispanic or Latino	Other	Female	CT	FALSE	TRUE	FALSE	FALSE
+49	Yes	10003752-kuLUfklt8EGKpPydGazbvw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+61	No	514382-038353	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	Yes	10000364-4963386	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+11	Yes	514382-011127	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+35	Yes	514382-008518	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	514382-000408	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	419639-005427	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+50	No	419639-004198	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+81	No	10000364-909169	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+58	Yes	514382-003116	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+85	No	514382-037063	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+68	No	10000364-6044238	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+88	No	10008204-x9SrMnOKFUCWmX8JOpQIOw	Not Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+59	Yes	514382-010287	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	514382-011009	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+23	Yes	10000364-1792031	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+64	Yes	10022779-mpRpxrFpIEqgMugGm37tOw	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+62	Yes	514382-012513	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+71	No	10003752-h45i9UxuZEW8cY45Yqv8Cw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+86	No	10008204-VKkKcPDBmEWLx4urJiUzaQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+90	No	419639-008968	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	No	514382-039209	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+51	No	514382-018235	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	10000364-6514244	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+76	No	419639-005554	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+32	Yes	10000364-1167371	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	514382-010198	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	514382-004580	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+72	Yes	514382-007237	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+39	No	10003752-5i9hiVCxMkrYs8k5RhCw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	419639-010987	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	Yes	10000364-789415	Not Hispanic or Latino	White	Female	MR	FALSE	FALSE	FALSE	TRUE
+42	No	10003752-M36lSBy0iWnbnXZ4ED8Q	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+42	No	419639-005442	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+39	No	514382-035617	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+66	No	10003752-C2L8efFylUUCs0kGH0r7Q	Not Hispanic or Latino	White	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+43	Yes	10022779-VgkusBUd4Ey3ZZaZFszyw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+78	No	514382-038596	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	514382-004582	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+77	Yes	514382-002575	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+79	No	514382-034852	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+24	No	419639-012525	Not Hispanic or Latino	Not Reported	Male	"DX,CT"	FALSE	TRUE	TRUE	FALSE
+37	Yes	419639-008466	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	514382-018139	Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	10003752-vLU8HOP2xkWhkNyJIz7ryw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+55	Yes	10022779-1ZiaUIpsYkmqYeY4uYoUoA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	Yes	10000364-2051604	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+32	Yes	514382-002384	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	No	514382-016728	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	419639-006898	Hispanic or Latino	Not Reported	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+60	No	514382-017086	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+71	No	514382-039436	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+59	No	514382-017000	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+26	Yes	10000364-2039320	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	No	10008204-eW3w6eZUA0uIAbieTFXVoA	Not Hispanic or Latino	White	Male	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+39	No	10008204-VkJ4k6ETEeWcUyVlwBDQ	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+44	No	10008204-JGf8PEdGfUClndFWgsXiSA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+46	No	514382-039190	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	No	10008204-3T3hHZHq70uNDB4muC7rrw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+60	Yes	10008204-Gnk0jDHvGEqeAD40jHsww	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	514382-004654	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+60	No	419639-002758	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+29	No	514382-015644	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	No	419639-008006	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+25	No	419639-002509	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+34	No	419639-001674	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	No	10022779-OB0LLqePpE2Z8voJKKsVA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	10008204-b5T22H3UUO7DQcD2gLhLg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+82	No	419639-009585	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	No	10008204-AjVYdC9GH0i4NR2Wpn5Zg	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+68	Yes	10000364-5378123	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+82	No	419639-010476	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+1	Yes	10000364-6398009	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+75	Yes	514382-001276	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+50	No	10008204-b5rkFoKIDEGmfy4ZfsD5pQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	No	514382-034723	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	Yes	514382-002584	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	514382-008722	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+19	No	419639-011851	Not Hispanic or Latino	American Indian or Alaska Native	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	No	419639-000760	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+40	No	10008204-WHK8MmSBkSjCKbu3lNfZw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+48	No	514382-036244	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	Yes	419639-008426	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+81	No	10000364-2029799	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+73	No	10008204-vP3U1BFdoEakICisoV4A	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+24	No	419639-007259	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	No	514382-015265	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+33	Yes	10000364-1519392	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+38	No	514382-036444	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+88	Yes	514382-009293	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+30	No	10003752-eDDkpWlwUeLx7Ke23yXxg	Not Hispanic or Latino	Black or African American	Male	"CT, CR"	TRUE	TRUE	FALSE	FALSE
+71	Yes	10003752-XIJqjS31BEeAEpHjdRNZgQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+60	No	419639-009875	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+35	Yes	10003752-DvQtQsx9bUCYiXIipkkxhQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+57	Yes	419639-010937	Not Hispanic or Latino	American Indian or Alaska Native	Male	DX	FALSE	FALSE	TRUE	FALSE
+73	Yes	10000364-1642367	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+26	Yes	514382-000536	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+60	Yes	514382-003478	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+41	No	10000364-1845303	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+55	No	419639-001826	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+25	Yes	514382-000482	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	10022779-HvzartiakWPzb94peqUXQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+22	Yes	514382-013595	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+35	Yes	10000364-1117647	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+74	No	10000364-689737	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+47	No	419639-004538	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+50	Yes	10022779-RurmDSa0mSAGbxzgSuFg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+71	Yes	514382-005280	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+43	Yes	514382-010068	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	419639-004184	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+50	Yes	514382-008701	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	514382-008178	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	10000364-5620851	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+78	Yes	514382-003728	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+73	No	10003752-0bdJuumgWEKWXUSwyHCctA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+41	Yes	514382-011651	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+36	Yes	10008204-FYNilXjTw0aoUYN9VmNIg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+80	Yes	514382-014125	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+75	Yes	514382-010232	Not Hispanic or Latino	Black or African American	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+90	Yes	10003752-A7U1zEQCmkKZ0GYkRPnA	Not Reported	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+45	Yes	10000364-2732012	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+890	No	10008204-sGlGgRKNSUqw0p7btAZz1A	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+60	No	514382-015604	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+36	Yes	514382-004278	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+82	No	10000364-1964727	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	No	10003752-iMLmvPGSm0SmwX4z9PVCw	Not Hispanic or Latino	White	Female	"CT, CR"	TRUE	TRUE	FALSE	FALSE
+54	Yes	514382-003306	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+72	No	419639-005745	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	10008204-sOMIB8wEjUOH8bppeenshQ	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	No	514382-034459	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+79	Yes	10008204-CIElbKjvA0WvMIn2phwo3Q	Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+58	No	419639-003074	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	No	419639-001335	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	10000364-14316	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-040873	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	No	10022779-JQ0ZyE6oOEylqSUxGogUg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	No	10008204-Xbti82bFkmCj5aIGPPYw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+41	Yes	10003752-zEmX9C23E6K0NVArbQZA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+75	No	10008204-GiNtWjVAE6hRhgc3raiVw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	Yes	419639-007961	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+59	Yes	514382-005853	Not Hispanic or Latino	Black or African American	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+71	No	514382-015708	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+56	Yes	10022779-cw7GSObjeE6ISgPNtkMedQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+47	Yes	514382-010349	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	10000364-1936954	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+53	No	514382-016538	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	No	419639-009815	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+78	No	10008204-rKhvUmiXfEi8q4o8ox7Pbg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+55	Yes	10000364-1975714	Not Hispanic or Latino	American Indian or Alaska Native	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	No	419639-004029	Not Hispanic or Latino	Asian	Female	"CR,CT,DX"	TRUE	TRUE	TRUE	FALSE
+34	Yes	419639-009567	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	Yes	10000364-1602657	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+60	No	10000364-6448866	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	No	419639-004894	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+81	No	419639-001268	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+69	Yes	10000364-5779279	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+73	No	10000364-5989813	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+57	No	10000364-5463374	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+67	Yes	10000364-1641327	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+55	No	10008204-wOCtc7nYCUmuwtKO2KV5Yw	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+52	No	10003752-1cHBPwD4fEO9Cgte15fnaQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+34	Yes	10022779-u8fEkOXAa0zkkQO5YCBJA	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+62	No	10008204-BYUooOmnhEa8Fyt7Blu6Q	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+34	Yes	514382-010644	Hispanic or Latino	Other	Female	"CR,CT,DX"	TRUE	TRUE	TRUE	FALSE
+78	No	419639-011714	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	514382-013828	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+88	Yes	10008204-oKFHVj4E0S3gajqnA4BgA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+54	Yes	10000364-819949	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+49	No	514382-036423	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	419639-012535	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+26	Yes	10000364-1513187	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+52	Yes	514382-012632	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+82	Yes	10000364-613125	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+76	No	10008204-7echwU6jESERnOy2QXxA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+47	No	419639-000060	Not Hispanic or Latino	White	Female	"CT, DX"	FALSE	TRUE	TRUE	FALSE
+67	Yes	10000364-226935	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+54	No	419639-011506	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	10000364-5248515	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+60	Yes	514382-012091	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+44	No	10000364-278058	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	No	10008204-crV0ZebOSkiPgwkGn7BaBQ	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	Yes	514382-012720	Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+62	Yes	10003752-NtYgyt3RkqwnYRyY9NFqw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+74	Yes	10008204-6ClZYaUWyUeRxgFVGYhy3w	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+71	No	419639-000812	Not Hispanic or Latino	Asian	Male	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+27	No	514382-018036	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	10008204-i8Vlhy0EQ0iE9Yxc1i312g	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+71	No	419639-011538	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+33	Yes	514382-003050	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+26	Yes	514382-002131	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	514382-001938	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+890	No	10008204-IebgT3cbyU2a6481DhAOlQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+67	Yes	10000364-1433121	Not Hispanic or Latino	White	Male	MR	FALSE	FALSE	FALSE	TRUE
+47	Yes	514382-012057	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	No	419639-011664	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+90	No	10008204-9cd0H1oeikywQttTtWNH4w	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+36	Yes	514382-002498	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+40	Yes	514382-013834	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+58	Yes	514382-003816	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+40	Yes	514382-002955	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+72	No	10000364-5514534	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+68	No	514382-040713	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+45	Yes	514382-008350	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	514382-006009	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+40	No	514382-035015	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	No	514382-034939	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	514382-006332	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	514382-013449	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+86	No	419639-009078	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+80	No	10008204-OK50fnNaESSRRzf0mclJQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	No	10000364-1107832	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	10000364-1649958	Not Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+69	No	419639-000570	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+79	No	419639-012011	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+78	Yes	514382-010088	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	10000364-6513705	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	10000364-1945887	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+69	Yes	514382-006679	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+19	Yes	10022779-RSnzV55utU6BleN4FggEA	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+30	Yes	10022779-Dd6KNiDiO0uAgFI5T4fBMw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+30	No	419639-002300	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+76	No	419639-004720	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+77	No	419639-005351	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+59	No	10000364-1749425	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+24	Yes	10008204-oDEktlzEw0QieB2hxTIbw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+80	Yes	514382-005425	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+26	Yes	10000364-4953095	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+67	Yes	514382-009602	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+84	No	514382-035545	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+34	Yes	514382-012497	Not Hispanic or Latino	Black or African American	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+58	Yes	514382-011997	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+35	Yes	514382-003145	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+8	No	10000364-2053783	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+36	No	514382-017371	Not Reported	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+29	Yes	10000364-1366891	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	10022779-LDWsZVjYEW7sEskTmYINQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+75	No	514382-015427	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+64	No	514382-037581	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	514382-010677	Not Reported	Other	Male	CT	FALSE	TRUE	FALSE	FALSE
+40	Yes	514382-004186	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	No	419639-002810	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+27	No	419639-011209	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+23	Yes	10022779-bdil57OhREG3UOJEXwC0bw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+51	No	10000364-720871	Not Hispanic or Latino	White	Male	"CR, DX"	TRUE	FALSE	TRUE	FALSE
+89	No	10008204-raaxk5E8K0OTz6E3P8bKmw	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	10000364-1338981	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	No	419639-001911	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+33	No	514382-036980	Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+24	No	10008204-yKcJ8U6UkidqPi8RJL4QA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+37	No	10000364-2309376	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+81	No	514382-038703	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	No	10000364-1941466	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+71	Yes	10000364-818205	Not Hispanic or Latino	White	Male	MR	FALSE	FALSE	FALSE	TRUE
+48	Yes	10022779-ekNufvJ9OE2ebRPBxO0ROA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+44	No	419639-003101	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+20	No	10008204-lKIaVYhVEk2gObSHV7ZPHg	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	10008204-YLgrhF0qLEOfALMDgyUvyg	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+33	No	514382-038880	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+5	No	10003752-ezohTMYxk4rmU0s2vqwA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+63	Yes	10022779-0pUXsPBa02vaxWOCRMxkg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+57	No	10000364-1641907	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+5	No	10003752-NfQ7PUKeUipHBgGEWcLA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	Yes	10022779-FYQlBWTEOUaTuDIQK82S0g	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+83	No	514382-038635	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+65	Yes	10000364-656303	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+45	No	10003752-wdTmVS6K0KeFdMrOg9MJA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+51	Yes	419639-012269	Not Hispanic or Latino	Not Reported	Female	"DX,RF"	FALSE	FALSE	TRUE	FALSE
+87	Yes	10003752-tGQK3UU89kGwq7QVNPZn3Q	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+60	No	10008204-gdnRYoJRNEC0R1lm0xqSfw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+41	Yes	514382-004510	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	No	10000364-1178786	Not Hispanic or Latino	White	Male	"CR, DX"	TRUE	FALSE	TRUE	FALSE
+75	No	10008204-1pzfUqtlKEeTZRwF5uPFnw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+53	No	514382-035964	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+74	No	514382-034936	Not Hispanic or Latino	Black or African American	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+61	Yes	10000364-1504999	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+27	Yes	514382-003952	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	No	419639-012576	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+54	No	514382-015321	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+34	Yes	514382-008379	Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+55	No	10000364-6572676	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	514382-005039	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	No	514382-015799	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+79	Yes	10000364-1019086	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+86	No	419639-001291	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+73	No	514382-038708	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+61	No	514382-034522	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	No	514382-016236	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+89	No	10003752-p46B1TjUEkCe75KpAgV6A	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+82	No	514382-039814	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+18	No	419639-010038	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+81	No	10000364-1428204	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+30	Yes	10003752-g5IgotzBv0mMYdVmb1opbQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	No	419639-003844	Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+39	No	419639-002501	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	10022779-CsCIuAdlF0i9g9I4FN86yg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+35	Yes	419639-010650	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+31	Yes	514382-014151	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+33	No	514382-038996	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+90	No	10008204-Tl96oeKRKkCiMWGjTw7A3Q	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+35	No	10022779-C5qYDnkXyUqvbpqwMAqfuA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+30	No	419639-000267	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	10022779-QWN6e7AMfEyhi8sdPt1F7Q	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+73	Yes	514382-000665	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+18	Yes	514382-004109	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	No	419639-010631	Not Hispanic or Latino	Not Reported	Female	"DX, CT"	FALSE	TRUE	TRUE	FALSE
+65	Yes	419639-004696	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+38	No	514382-034737	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+31	Yes	10022779-JasK6W0eUKvADAk5giClw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+28	No	514382-034224	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+59	No	514382-015944	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	No	10008204-QogD5AEE20GzU9ZSnQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	No	514382-038778	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	514382-000046	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	No	419639-009650	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	514382-011601	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	Yes	10000364-1764453	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+68	No	419639-003985	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+35	Yes	514382-001937	Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	No	514382-018169	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	514382-012764	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	No	419639-001676	Not Hispanic or Latino	White	Male	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+79	No	514382-017752	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	No	10000364-2091259	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+56	Yes	514382-006820	Not Hispanic or Latino	White	Male	"CR,CT,DX"	TRUE	TRUE	TRUE	FALSE
+79	No	10008204-j6OmkPMEn0yqpESjl8XRjA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+39	No	419639-011709	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	No	419639-002966	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+65	Yes	514382-009979	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+890	Yes	514382-013241	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	Yes	10000364-5220004	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+80	Yes	514382-004780	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	Yes	419639-012273	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+48	No	419639-009250	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	No	10008204-1bwsbsRKxkOSemRhMN9tCA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+33	No	419639-000667	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+81	No	10022779-bCdUtWmaEgaCeXMjeu3Q	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+79	Yes	10000364-6492316	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+50	No	514382-038182	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+32	Yes	419639-012075	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+49	No	419639-004414	Hispanic or Latino	Not Reported	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+70	Yes	514382-001952	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+85	No	514382-039750	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+35	No	514382-015861	Not Reported	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+44	No	10000364-1127813	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+20	No	10003752-JNbOI9rlb06XPyQG75lOxA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	No	419639-001727	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+81	Yes	419639-011328	Not Hispanic or Latino	Not Reported	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+56	Yes	419639-012425	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+31	No	514382-037386	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	10022779-1J1K4sjiiEiPLDWJDGyLA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+58	No	514382-036483	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	No	10000364-1394833	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+82	No	514382-036514	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+890	Yes	10022779-gcDacix9kSUy1QP0M6Jw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+43	No	10008204-lzcAHgkNrUigQgW2C80Vg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+63	Yes	419639-003956	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	514382-012246	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	No	10003752-zv2RCgHyUyxSmamMQkAQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+46	Yes	514382-006165	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+83	No	514382-034760	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+48	No	514382-036912	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	No	419639-001179	Not Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+31	No	10008204-Qx7tM3S7Eu9HgSHvHfgYg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+71	Yes	514382-008481	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+71	No	10003752-IjxtOX8P0eMvJhyfBYdHw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+54	No	514382-039846	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+29	Yes	10000364-1471581	Not Hispanic or Latino	Black or African American	Female	"MR,DX"	FALSE	FALSE	TRUE	TRUE
+18	Yes	514382-009898	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+50	No	10008204-YPsTp5l1gUqxYETEGfAEfw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+46	No	419639-003070	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+41	No	514382-040393	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+38	No	419639-012309	Not Hispanic or Latino	Not Reported	Female	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+61	No	514382-034069	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+52	No	10008204-4wHrbZxyo0iXakspOn86Dw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+77	No	419639-001236	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+67	Yes	10000364-1606954	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+81	No	419639-002408	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+80	Yes	514382-000540	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+39	Yes	10022779-NkUWE9x15k2mb4K08bumQ	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+77	Yes	10003752-nI5Qzzdf0uFv0ttuopr9Q	Not Hispanic or Latino	Black or African American	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+68	Yes	10022779-efy4bXJc0UOYNBcwBq9tLw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	514382-001268	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	514382-002208	Not Hispanic or Latino	White	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+32	Yes	514382-009231	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+67	No	10008204-TzaEr6Kmd06ooYqrczuz0w	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+86	Yes	10003752-pG2xdNIo0WKWoUrhtzAjA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	Yes	10000364-1021794	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	No	10000364-2444811	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+66	No	419639-002040	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	No	514382-039780	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+75	No	10000364-2726246	Not Hispanic or Latino	White	Female	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+32	Yes	10000364-6131506	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+62	Yes	514382-006718	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	10003752-ws3f6z2mPUyHc5gV1J5b9Q	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+22	Yes	419639-006050	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+83	No	419639-011492	Not Hispanic or Latino	Asian	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+59	No	10003752-GaNatus5c0eNy1txIytdyA	Not Hispanic or Latino	Asian	Male	CT	FALSE	TRUE	FALSE	FALSE
+72	No	514382-035465	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+38	No	514382-040296	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	10022779-ZeJ94xThJEzas5ysUVIRg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	419639-006722	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+69	No	10022779-KBLWAouxUSTMj8g8dQqA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+68	No	514382-014738	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	No	514382-036536	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+40	No	10022779-SUSyUKOgRkmaGsziuJFYQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+57	No	419639-009991	Not Hispanic or Latino	White	Male	MR	FALSE	FALSE	FALSE	TRUE
+53	No	514382-035136	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+77	Yes	514382-012968	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	No	514382-037617	Hispanic or Latino	Other	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+52	Yes	419639-011234	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+890	No	10008204-G0yau6xw0kuSl1w49oY8QA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+35	No	10022779-rptKnzkQHk6kVBIzh5SiQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+35	Yes	10022779-ZL1CTuDtJU676Yn3XQt5A	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+60	Yes	514382-012111	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	No	419639-008993	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	Yes	514382-001355	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	Yes	10022779-L5ZUVJdE6pgxws0vXw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+77	No	10003752-r43Q2j8UnUGRyZMlJPypHw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+26	No	514382-015187	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+42	Yes	10000364-2329348	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+31	Yes	514382-001351	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	Yes	514382-000389	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+84	No	514382-040460	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	No	10008204-2nEfPqTWnUC7WitD2jOdzA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+44	Yes	514382-007696	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+49	No	419639-009777	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+59	No	10008204-7BGYGBhjOE2wx4VMS12YiQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+41	No	514382-038331	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+52	No	419639-009526	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	514382-005602	Hispanic or Latino	Asian	Male	CT	FALSE	TRUE	FALSE	FALSE
+45	Yes	10022779-CokTqcj6EK3XKHOy25Hw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+89	No	10008204-Q9IsYXvRVUKFWG66drQ0Hg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+75	No	419639-001255	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+65	Yes	10022779-4segfO9WNUqkF1U0F5IPA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+41	Yes	514382-007779	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+52	Yes	10000364-1583013	Not Hispanic or Latino	Black or African American	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+49	No	10022779-iUddqxfZkmHXSsVzO9fRw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+22	Yes	10008204-VzThvoojkCDL91zEFizRg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+86	Yes	419639-006642	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	Yes	10022779-dBmT8T30b0WtSTjYTAUh6w	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+63	Yes	419639-001214	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+82	No	514382-039020	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+44	No	10000364-1490158	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+73	No	514382-035463	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	No	10008204-KzxAsWYyEmmU7CqrgvnQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+69	No	10008204-TyGOE8voBUOpTgXWO3l8wQ	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	Yes	10003752-gpL30OBvm0i11u5OHpTAwA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+55	Yes	514382-002093	Hispanic or Latino	Other	Female	CR	TRUE	FALSE	FALSE	FALSE
+39	No	10000364-1906607	Not Hispanic or Latino	White	Female	"CR, DX"	TRUE	FALSE	TRUE	FALSE
+60	No	419639-011336	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	10000364-2368998	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+88	Yes	514382-007292	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	No	10008204-FeUzoILXq0mqFXvq7mTvmA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+33	Yes	10003752-znD03VIVAEqDN7s84cwzpw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+89	No	10008204-2ik2QHJ2X0iZeWXYgYxVRw	Not Hispanic or Latino	White	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+45	No	419639-000197	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	10022779-9MVpURqjJ0e9QHy6zwz4Fg	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+80	No	419639-011654	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+85	No	10008204-A1jS68Kkr0W0Z3TVZvV4QQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+63	No	419639-001519	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+68	No	514382-033824	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+87	Yes	10003752-5BtUkHSIzkEwgVU4uwvAA	Not Reported	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+67	No	419639-010980	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	514382-010003	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	10000364-1646757	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+81	No	419639-012639	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+36	Yes	514382-002741	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+37	No	10003752-rC5xy8i1bkaQyNuxtQanUg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	514382-005591	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	No	514382-016148	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	10000364-2107508	Not Hispanic or Latino	White	Female	CTPT	FALSE	TRUE	FALSE	FALSE
+28	Yes	514382-000777	Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+39	No	419639-000118	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	10000364-1206123	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+25	Yes	514382-001681	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+67	No	10008204-pYgRCTMjdUqXXBQkcpmGg	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+1	Yes	10000364-6266581	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+87	No	514382-016998	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	No	514382-040360	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+41	Yes	10000364-2615741	Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+49	Yes	419639-007422	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	No	10000364-5257518	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+81	No	10008204-266lz2vbA0KUxILz5xMuwg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+45	Yes	10022779-2BjiQWiye0SXZECblRvwAw	Not Hispanic or Latino	Native Hawaiian or other Pacific Islander	Male	CR	TRUE	FALSE	FALSE	FALSE
+73	No	10008204-22Io6Ixn0uFL2IfG1b2kA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+24	No	514382-016491	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+50	Yes	514382-013300	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+32	Yes	10000364-6265513	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	No	514382-016202	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+72	Yes	514382-005866	Not Hispanic or Latino	Black or African American	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+47	No	10022779-EhwYPpzyDUufMsnrNMzQNA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+44	Yes	514382-013236	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	No	10000364-5208391	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	No	419639-011375	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+48	Yes	10022779-ftyXvtBZ1UCfO3zwfAIEJA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	No	419639-008114	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+29	Yes	10022779-LBiYFhOV0WCiTxh472GLw	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+56	No	514382-017191	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+73	No	10000364-6142680	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+67	No	514382-038022	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+22	Yes	10000364-1366791	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	No	514382-038532	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+890	No	10008204-mc2SSzwbRkGF36Idm2G1Hg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+90	No	419639-011146	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	419639-012429	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+40	Yes	10022779-X3rce8FWUFske6jvpiog	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+28	Yes	514382-013533	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+79	Yes	514382-005315	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+33	No	514382-035415	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+62	Yes	514382-010411	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	514382-007060	Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+88	Yes	10003752-WRHmgFHch00GU4s3Cn1SA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	No	419639-003535	Hispanic or Latino	Not Reported	Female	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+40	Yes	514382-005609	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	514382-013611	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	10000364-6369800	Not Hispanic or Latino	White	Male	CTPT	FALSE	TRUE	FALSE	FALSE
+38	Yes	514382-006807	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+38	No	10000364-1826031	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+82	Yes	514382-007442	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+75	No	514382-041317	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+89	No	10008204-cFi0sAgjuEiu4R2WfNjwpA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+63	Yes	514382-002654	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+44	No	10008204-pxLmU4ZIEaE6Q3d71ZVBA	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	No	514382-037287	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+890	Yes	514382-001630	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	514382-013285	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+35	Yes	514382-003641	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	419639-009177	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	No	10000364-1568698	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+70	Yes	514382-010199	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+67	No	10008204-JMaxt6qwkyrave9zrqshg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+22	Yes	10022779-2VPCh62nkkFpRltOE1g	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	No	10003752-Gai5dzM70UGw8dJM1luUQw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+58	No	10000364-794728	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+15	Yes	10008204-fBpyspNr0q83K2J82aIjA	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	10003752-kWmoO7r1V0igMqJ6d9rh9g	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+72	Yes	10000364-1096640	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+31	Yes	514382-012839	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+40	No	419639-011773	Not Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+58	No	419639-000900	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	10003752-fLYeZ3LamkOqddPyjjculg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+65	Yes	10022779-Ax8BfdyU0EiTT5dWniJjMg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+37	Yes	514382-010527	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+1	Yes	10000364-6542655	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+52	No	419639-002596	Hispanic or Latino	Not Reported	Male	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+30	Yes	514382-010669	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	No	514382-035064	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+62	No	10008204-6G46sNduUmToVfezJxInQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+58	No	10008204-sm0b1yyrNkKVGRGnbu7sHw	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+62	No	419639-004189	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+51	No	514382-041093	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	514382-010449	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+71	No	10008204-ssjIcBuyU02D7Q6e3Tv2Aw	Not Hispanic or Latino	Asian	Male	"DX,CT"	FALSE	TRUE	TRUE	FALSE
+64	Yes	10022779-LUGroDeWxEmcoerFUaUXMg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+63	Yes	10000364-5213282	Not Hispanic or Latino	Asian	Male	CT	FALSE	TRUE	FALSE	FALSE
+85	No	514382-014942	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+52	No	10008204-7j2rszGj5UGPmhwcblG63w	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+71	No	10008204-su2Fyr4aR0qJ9FkAKNfVWQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+41	Yes	10008204-arijEdSTkEyGtyOUH55gw	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+87	No	10008204-e6fAX7psgEWkoh3zJukHA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+55	Yes	10003752-LifUFLfcyESlBBhFXynpRw	Not Hispanic or Latino	Asian	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+76	No	514382-039643	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+39	No	10008204-adBp25bsZ06et7ltbEf51w	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	514382-011274	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	No	419639-004435	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+26	No	514382-037031	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+42	Yes	514382-008730	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+77	No	10000364-217119	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+65	No	419639-004074	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+52	Yes	419639-002267	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+62	No	10008204-yQUWTm59UWWHPAtl7TfnA	Not Hispanic or Latino	White	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+55	No	419639-005607	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+70	Yes	10022779-OPgV8pxt0eYBKdk2esubQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+90	Yes	10003752-8r7eY9mnSEKrZROuzjqw	Not Hispanic or Latino	Black or African American	Female	"CR, CT"	TRUE	TRUE	FALSE	FALSE
+62	Yes	10022779-QwXadgu0Lk3FOrTrLEiIA	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+51	Yes	514382-003662	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+43	No	514382-039446	Hispanic or Latino	Other	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	Yes	514382-010683	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	No	10008204-ZmfmlmVTSkeRELtPBjizQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+71	No	10000364-2681290	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+82	Yes	10003752-pzA7R5XykLNc7gRuyimw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	No	514382-039095	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	10022779-JCnKVcH46EOm4iC2uJqCHA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+46	No	10000364-2438838	Not Hispanic or Latino	White	Male	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+39	Yes	419639-004036	Hispanic or Latino	Not Reported	Female	CT	FALSE	TRUE	FALSE	FALSE
+46	Yes	10008204-ZZ8dWXo6Y02YIgwZz6jF5Q	Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+70	No	419639-010007	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	No	10000364-1610672	Not Hispanic or Latino	Black or African American	Female	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+59	Yes	10022779-dWVUBECN4kqZUAjGfjch5g	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+73	No	419639-000068	Not Hispanic or Latino	White	Female	"CT, DX"	FALSE	TRUE	TRUE	FALSE
+46	Yes	10008204-s6XQbxxi4k6n7VgFgSNHhQ	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+42	Yes	10022779-3C6oYF0n1EK0JscAjmkOQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+37	Yes	419639-010413	Not Hispanic or Latino	Not Reported	Male	"DX, CT"	FALSE	TRUE	TRUE	FALSE
+890	No	10008204-EuSJ2r2tkqWJlERRVut8Q	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+51	No	10000364-6374356	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+28	Yes	10022779-3tavi8fTULjFlzZYc3g	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+49	Yes	514382-008136	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+33	No	514382-015966	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+19	No	10008204-K6WmNO0hBkmZQZ96Ru7mgQ	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+88	No	10008204-n6cTVGOUckG6vAOEkUjTA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+51	No	514382-037484	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+52	No	514382-039826	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+40	Yes	514382-001367	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	No	419639-000232	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	No	10000364-5709266	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+40	Yes	514382-011169	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+45	No	514382-036379	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+30	Yes	10003752-CvM1w5AUCF8OuG1ljlQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+80	Yes	514382-014192	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+36	Yes	10022779-PNrAWsjhEyeq7YBTWUDRQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+67	Yes	10022779-lrIJa2NSZ07bD2Nh6d16A	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+31	No	419639-003317	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	No	419639-001295	Hispanic or Latino	Not Reported	Female	CT	FALSE	TRUE	FALSE	FALSE
+51	No	514382-041421	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	514382-000798	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+28	Yes	514382-003280	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+52	No	419639-004199	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+48	Yes	514382-009541	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	No	514382-016870	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+23	No	514382-015665	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	Yes	514382-011600	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	514382-001489	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+29	No	10008204-NJWXEENkqH0UBTigsvHA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	Yes	419639-004306	Not Hispanic or Latino	Asian	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+74	Yes	10000364-1431629	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+85	No	514382-034923	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+50	Yes	10003752-Nxqf6p6ez0tfjncdd3QVA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+40	No	514382-017700	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	No	419639-012019	Not Hispanic or Latino	Not Reported	Female	"DX,CT"	FALSE	TRUE	TRUE	FALSE
+48	Yes	10022779-sF3ra1QOkyI6wguFo8ww	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+27	No	419639-003471	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+39	No	10022779-K4xoP2JTlkSY946Du60w	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	No	10008204-JplqU42KhUa8XLjEA7ipng	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+46	Yes	514382-010345	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	Yes	10003752-nruMdpMIZkWBbnCZqOOgg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+48	No	10008204-RbxsBFGzeUefK6V8UbFKA	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+72	No	419639-001656	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+52	No	419639-009156	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	No	419639-008516	Not Hispanic or Latino	Asian	Male	CT	FALSE	TRUE	FALSE	FALSE
+68	Yes	514382-013023	Hispanic or Latino	Other	Male	CR	TRUE	FALSE	FALSE	FALSE
+67	Yes	10022779-tZ44yAxaT06o2ZkKm4qJkg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+22	Yes	10000364-40182	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+26	Yes	10000364-2372732	Not Hispanic or Latino	White	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+90	No	10008204-0wk0xLgx706FQuZTwX5Rvw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+58	Yes	514382-014030	Not Hispanic or Latino	Black or African American	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+85	No	419639-011498	Not Hispanic or Latino	Not Reported	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+90	No	10008204-ROxT3eOKq0qbmbAl8H2n8w	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+90	No	10000364-5249189	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+58	No	419639-002343	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	10000364-1184511	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+67	No	10008204-7gojGzY0KEOdkfQ3mjpBZw	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+64	Yes	10003752-absJXBvbI0usMkXy118IlQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	No	514382-038534	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	514382-007784	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+89	Yes	514382-007289	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+43	Yes	514382-000492	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+90	No	10000364-1515454	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+81	No	514382-039497	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	No	514382-038371	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	514382-005045	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+89	No	514382-040528	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+52	No	419639-003103	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	No	419639-005817	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+26	Yes	419639-009343	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+68	Yes	514382-009795	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+41	Yes	10000364-1615569	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	514382-012459	Hispanic or Latino	Other	Male	CT	FALSE	TRUE	FALSE	FALSE
+89	No	10000364-5752040	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+37	No	419639-008969	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+28	Yes	10022779-f47fL98HUWFexUGFHo0A	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+42	Yes	514382-013087	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+80	No	10000364-6580025	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	No	419639-003832	Not Hispanic or Latino	Black or African American	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+79	No	10008204-SMMonJgHfkqUfaZNnSgBA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	Yes	10022779-olsnwwoQPU6l04zpIJCJw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+85	Yes	514382-000386	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	10000364-1030129	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+34	No	419639-005150	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+38	Yes	10022779-J2zRR3stEEu2yyvhTNUa0g	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	514382-002183	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	10000364-2092516	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	Yes	10022779-d8byCzNw0qMSSUrjrTSbQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+31	Yes	514382-002957	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+19	Yes	514382-008824	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+88	Yes	514382-012498	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	10022779-uWLQFniEGijxzUC7NPpg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+39	No	419639-004830	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+25	Yes	514382-004061	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	10000364-1504672	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+85	No	514382-015552	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+31	Yes	10022779-TtNLs8lPwkS6PX7LwKA9A	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+90	No	419639-003854	Not Hispanic or Latino	Asian	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+70	Yes	514382-000805	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	10003752-Y2oYuxmHd0alk0dWU9JNg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	No	514382-035480	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	No	514382-034041	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	10022779-JFkiIYhRUUCWDik5I9JUg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+46	No	419639-001139	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+78	Yes	10022779-BsTBA0QkGPprvVJaPOoQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+57	Yes	10003752-v0jF1j03qEqwbXKCzeEFOg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	Yes	10000364-1549846	Not Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+890	No	10008204-H7iHMlv3E2T9yYmCtX5cg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+72	Yes	10000364-6551450	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+63	No	10000364-5908236	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	No	419639-002705	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+36	Yes	514382-006259	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	No	514382-035881	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	10022779-lfgrogEnVEGuC4KJpTGh2w	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+69	Yes	10000364-5799196	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+40	No	10003752-DJWKgRI3Q0O0ZhPdrzmeg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+32	Yes	10022779-Yzs7OQiUqp9EMYfEqMIQ	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+47	No	10003752-9zreKqDK50GsFBXSha7QWA	Not Hispanic or Latino	Black or African American	Male	"DX,CR,CT"	TRUE	TRUE	TRUE	FALSE
+46	Yes	10022779-D7rJU1xUkiSjUPTjIm4ZA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+72	No	514382-040779	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+48	Yes	514382-000474	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+24	Yes	514382-011611	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	Yes	514382-000424	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	514382-007055	Hispanic or Latino	Other	Female	CR	TRUE	FALSE	FALSE	FALSE
+54	Yes	419639-010048	Hispanic or Latino	Not Reported	Male	MR	FALSE	FALSE	FALSE	TRUE
+61	No	10000364-1414653	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+31	No	10008204-98v9R6FfkEO99VadOBbi0g	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+45	Yes	10000364-1497229	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+30	No	419639-000855	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	419639-009451	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	No	514382-038850	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	Yes	514382-002215	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	Yes	10022779-RqfalPTI40SU3fhV4ADagA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+39	No	419639-001033	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+73	No	10008204-tuqFjAHZkeZNHfbQU9eA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+63	No	514382-038707	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+47	No	514382-017977	Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	No	10008204-dJDyIAwITE6lUPmrB1mZvQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+42	Yes	10000364-5537423	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+68	No	10008204-yrTcD3uuxkq6QONt6NCszA	Not Hispanic or Latino	White	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+48	No	10008204-AiVTQVyqp0SPkCOJEpoGSg	Not Hispanic or Latino	White	Female	"CT,CR,DX"	TRUE	TRUE	TRUE	FALSE
+31	No	514382-016497	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+57	Yes	514382-002751	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+78	No	419639-007048	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+24	No	10003752-aKna7FrEYUmdAwAMbtX1vA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+71	Yes	10008204-QXlqGHeg5Eq2Arix7xbuEw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	No	514382-015239	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	514382-008578	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	No	514382-040267	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+67	Yes	514382-002802	Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	No	10008204-GcSbRyl66kCzo9EFdRjcyw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+59	No	10022779-Fo0QT7ssj0Ks8DZrfDFB4A	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+79	Yes	10003752-7VZX3Vgqok2CfXZsc7Icug	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+45	Yes	514382-006908	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+89	No	10000364-1575671	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+64	Yes	10000364-1507248	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+43	No	419639-011332	Not Hispanic or Latino	Not Reported	Female	CT	FALSE	TRUE	FALSE	FALSE
+84	No	514382-015507	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+43	No	10003752-yTjyKsiCuEqB68OZffNlxQ	Hispanic or Latino	White	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+42	Yes	10022779-HlZNbubEWYPMgpPuhNFw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+63	Yes	10000364-1647503	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+72	Yes	10003752-BFZnoOrFqEi7dT0p2Hgw	Not Hispanic or Latino	Black or African American	Male	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+84	No	419639-011507	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+73	No	514382-015935	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+77	Yes	514382-012953	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+51	Yes	10003752-vKKevI9Y7EyR8338lBiKyw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+75	No	514382-015713	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+34	No	514382-016981	Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+86	Yes	514382-005363	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+67	No	419639-003268	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	No	514382-036391	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	419639-012433	Not Hispanic or Latino	Not Reported	Not Reported	DX	FALSE	FALSE	TRUE	FALSE
+71	Yes	10022779-4baGt7YWUSJA35J6GyCA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+18	Yes	10000364-1216169	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-015375	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	No	10000364-819459	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	514382-012053	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	10008204-pm1Vg3dLbUmvqOlfbxILfQ	Not Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+20	Yes	10008204-5iehmim0LUqxVJpyn5TN1Q	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+52	Yes	514382-004183	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+77	No	419639-010216	Not Hispanic or Latino	Not Reported	Female	"CT, DX"	FALSE	TRUE	TRUE	FALSE
+79	Yes	10000364-1421997	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	10022779-AkULISfWQUOfUUaXZ84h3w	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	No	10008204-7UVfuAKYNUmhZqYONZJzlw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+32	No	514382-014791	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+46	No	514382-039043	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+24	Yes	10022779-LCVwX0CH0CHqIG4f4yow	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	514382-011454	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	10003752-jivwEIdGkCZM3CEuPcA	Not Hispanic or Latino	Black or African American	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+31	Yes	514382-004296	Not Hispanic or Latino	Black or African American	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+65	Yes	10000364-2014565	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+81	Yes	10000364-311109	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+72	Yes	514382-011413	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+53	No	10000364-5272782	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+38	Yes	10022779-bB9dsKA0mkqD9uUNWVuw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+45	Yes	514382-011931	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+56	Yes	10000364-6604610	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	Yes	10000364-612197	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+63	Yes	10022779-rDzx7a5FP02DAM0gcS9MtA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+56	No	419639-000723	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	No	514382-035466	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	Yes	10022779-rxAeAjwaEKgB9UzZaP0tw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+42	No	514382-033806	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+65	No	419639-002605	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	419639-003882	Hispanic or Latino	Not Reported	Male	"DX,CT,CR"	TRUE	TRUE	TRUE	FALSE
+74	No	419639-001338	Not Hispanic or Latino	White	Female	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+64	No	514382-013700	Not Hispanic or Latino	Asian	Male	CT	FALSE	TRUE	FALSE	FALSE
+45	Yes	10000364-6556489	Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+60	Yes	10003752-mmiwlTfpME6j99fCYen30Q	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+74	No	10008204-l4qJKlsmhE6I02ee6saAgA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+55	No	10003752-hAhR0JCnUgzcpKyQpBA	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+44	Yes	10000364-5926522	Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+47	No	419639-011099	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+48	Yes	514382-001653	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+19	Yes	10000364-1468089	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+61	Yes	514382-013051	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	No	419639-007870	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	No	10000364-5364203	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+58	Yes	514382-009722	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	No	419639-011568	Not Hispanic or Latino	Not Reported	Female	"DX,CT"	FALSE	TRUE	TRUE	FALSE
+65	No	10000364-1584658	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+54	No	10022779-Vgd8gEQekKQHDRSptxSdw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+85	No	10000364-1569812	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+25	No	514382-015660	Hispanic or Latino	Other	Male	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	514382-010355	Not Hispanic or Latino	Black or African American	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+59	Yes	419639-011718	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+80	No	514382-018197	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	514382-012387	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+15	Yes	514382-008709	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+59	No	419639-008833	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+17	No	10000364-1239080	Not Hispanic or Latino	White	Female	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+53	Yes	514382-013045	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+36	Yes	514382-003047	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	514382-011262	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	10000364-5353134	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+59	Yes	514382-002829	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+30	Yes	514382-004540	Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+34	Yes	10003752-EcSMpMtyEuimQZkFrRufg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+51	Yes	514382-011430	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	10022779-6AnJiyoKs0GqrKuejzvVxQ	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+71	Yes	10000364-706310	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+47	No	419639-009584	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	No	514382-016025	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+57	No	419639-007727	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+74	Yes	514382-006435	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	No	10000364-1820806	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+37	Yes	514382-001994	Hispanic or Latino	Other	Female	CR	TRUE	FALSE	FALSE	FALSE
+43	Yes	514382-010073	Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+25	Yes	10000364-913336	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+67	No	514382-037998	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+20	No	10008204-bxuilrHfeEao2ddxoEpNXw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+39	No	10000364-1330058	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+43	Yes	10003752-nA6s4H0fPEWLfN4jbEtRKg	Not Hispanic or Latino	Asian	Male	CT	FALSE	TRUE	FALSE	FALSE
+890	No	514382-037025	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+35	Yes	10022779-P5TR5vjzAk6YgMkZS94iEA	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+39	Yes	514382-003092	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+27	No	419639-001658	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+56	No	419639-006235	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+38	No	419639-003694	Hispanic or Latino	Not Reported	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+50	Yes	10000364-1488026	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+65	No	10022779-YWToo9IDqk28rHius9L3Jg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+83	Yes	10003752-SIQrULeYu0aa2wj0Vlc8ZQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+31	Yes	514382-004356	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+81	Yes	514382-007666	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+57	Yes	10000364-1638984	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+51	No	10008204-vGdOxPIpqUiAMMYmcKTYTQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	No	10000364-1310712	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	No	10000364-1497645	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	10003752-onuRNmV3c0Cc76u5GzPF3Q	Not Hispanic or Latino	Black or African American	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+40	No	10003752-vjhU84o8s0SA7kFr3zBQuQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+66	No	419639-007049	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	No	514382-036756	Hispanic or Latino	American Indian or Alaska Native	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	No	419639-006747	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+81	No	419639-009950	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	Yes	419639-010194	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+73	Yes	514382-006913	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+26	Yes	10000364-5886762	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+81	Yes	10000364-879001	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+77	No	10008204-hiWgGI8KfEeYWhXVGvgkg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+14	Yes	10003752-abNPs7fgnUfCLFQf4MYJA	Hispanic or Latino	Not Reported	Male	"CR, CT"	TRUE	TRUE	FALSE	FALSE
+56	Yes	10022779-RSNzPA8gt0qKkFuTnSApew	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+69	Yes	10000364-1512849	Not Hispanic or Latino	Black or African American	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+61	No	514382-039510	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+62	No	10008204-88RIAD3J0qkxpfQs7KtHQ	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+44	Yes	514382-013076	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+33	Yes	10003752-RDUxS2zXxEaOv3dSRYSYLQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+69	No	514382-034011	Not Hispanic or Latino	Asian	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+80	Yes	419639-002784	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+72	No	10008204-QcHTU0I0HkiW0qu3GvR8sQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+56	No	514382-017471	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+71	Yes	10000364-1436212	Not Hispanic or Latino	Black or African American	Male	MR	FALSE	FALSE	FALSE	TRUE
+19	Yes	10000364-1260475	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+48	No	10008204-JBIQonpjUG60kxkTRbwMQ	Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+77	Yes	514382-011638	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	514382-006016	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+64	No	10000364-1908355	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+42	Yes	514382-012669	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	No	514382-041217	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	No	10003752-JfReU8YmWU5t9sH9opXNg	Not Hispanic or Latino	Black or African American	Male	"CT, CR"	TRUE	TRUE	FALSE	FALSE
+46	Yes	10008204-p0RDwYQ7RUaYtX7hnNPjgw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+77	No	10000364-5304119	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	No	10022779-tiyBaH0K0OX9t2N5IcBw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+75	No	10003752-nmPUPEHdEECTgGe45YSsPQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	Yes	10008204-QCqvrZ8qkWVgyjfFcrRg	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	No	419639-000794	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+40	Yes	10000364-1583516	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+68	Yes	419639-004197	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+79	No	419639-001474	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+89	No	10008204-lWmeKnoJVkGAaYEidXWphQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+85	No	419639-008827	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+43	Yes	419639-006548	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+40	Yes	10003752-eLkZSeqJxky2kRJF71sIw	Not Hispanic or Latino	Black or African American	Male	"CR, CT"	TRUE	TRUE	FALSE	FALSE
+64	Yes	10022779-yExK8xdmI0CxVZWEvmKRQ	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	419639-008600	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	10000364-1307764	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+33	Yes	514382-000832	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+83	No	419639-008755	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	10022779-XrYv1FykSEmzHq9mTSB1cQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+82	No	419639-007976	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+11	Yes	10000364-6453076	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+66	No	419639-006357	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+84	No	419639-011703	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+71	No	514382-017197	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+26	No	10008204-OQ6KnTJDikO1Ky8Omo5j1w	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+33	No	419639-010033	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+77	No	10008204-8UfSWaTmCUavaFVbBzxtrA	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+79	No	419639-003508	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+60	No	10003752-4j5WAthhX0KadxWxEBLnQ	Not Hispanic or Latino	White	Female	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+47	Yes	10000364-1825671	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+34	No	514382-016999	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+81	Yes	10000364-5553322	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	10008204-MTUTsWXXEqVcXEzJ143sQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+63	No	10008204-QHqF3QymMU2ROFDRafaQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	Yes	10000364-6556557	Hispanic or Latino	Native Hawaiian or other Pacific Islander	Male	CT	FALSE	TRUE	FALSE	FALSE
+26	No	419639-007868	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+16	No	10008204-8SNmIS7OUaC8U8Wo0VbFg	Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+78	Yes	514382-006157	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+77	Yes	10000364-1632048	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+51	Yes	514382-008123	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	Yes	419639-011353	Not Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+51	Yes	10022779-1zVvBBUlEkqLsh41MTwDZA	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+76	Yes	10008204-OjZgC4qWUGGSVxl7dDA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+63	Yes	10022779-4UxyFKowxUmuIchQv1hBjw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+44	No	419639-003264	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+30	No	419639-002503	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+53	No	419639-000517	Not Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+57	No	10008204-cDZZxBrmvEqcX9LXdL0OZg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+78	No	10008204-r0pSdLVk5UaNIbDw9eSuQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	No	10008204-PHWNEGnxKkafJx65ec4Lcg	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+81	No	10008204-U4AyzkAPUqBXTVd9SjIw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+41	No	419639-000438	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+78	Yes	10000364-1102002	Not Hispanic or Latino	White	Female	"CT, CTPT"	FALSE	TRUE	FALSE	FALSE
+50	Yes	10022779-J2L5tTDhk0WEY1RDqPbY6w	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+72	Yes	514382-006713	Not Hispanic or Latino	Asian	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+21	No	10008204-ARQUsDituU6Kcm6IS8K2Ow	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+78	Yes	514382-007090	Not Hispanic or Latino	Asian	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+55	Yes	514382-004120	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+88	No	514382-039754	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+66	Yes	10003752-a2tQF6Xs8UCIbVw2Oi1ITA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+44	Yes	514382-003428	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+53	No	10008204-SsX6IUtDcUKvssqkxTx58Q	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+75	No	419639-005691	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	No	10008204-e6jJSZcWsUam9EQWkTWFg	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+26	No	514382-018052	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+36	No	514382-038807	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+28	Yes	514382-001391	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+52	Yes	10000364-1015188	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	No	514382-036494	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+38	Yes	419639-008108	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	Yes	10022779-JCuE5ISpcEaO9PdKW0D4QA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+56	No	10022779-4ZPdUKgJzkqggu9B0ieqIA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	No	514382-038392	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+28	Yes	10000364-5551069	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+28	Yes	10022779-KUJFusmgJU6w58RBa6ISQ	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	10008204-LVQ2xf6tv0KDeZkxhcZUA	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+48	Yes	10008204-3xIEntMdU2eneVy1LPuw	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	No	514382-017410	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	514382-000603	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+50	Yes	514382-003652	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+46	Yes	10022779-kxsRG9HFECxwqoI5mwZA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+43	No	10003752-MGN2jrSkmmknW91r0fyw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+43	No	514382-039495	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+77	Yes	514382-000796	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+81	No	419639-002640	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	10008204-tIL3MnzIlUiOJS1HBUJguA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	Yes	10000364-2443852	Not Hispanic or Latino	White	Female	CTPT	FALSE	TRUE	FALSE	FALSE
+62	No	10000364-2472877	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	No	514382-039561	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	Yes	514382-000387	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+80	Yes	514382-006511	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	Yes	514382-011579	Not Hispanic or Latino	Black or African American	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+50	No	10003752-SUPjiran4U6mvWoM400ZqQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+90	Yes	419639-010708	Not Hispanic or Latino	Not Reported	Female	"DX, CT"	FALSE	TRUE	TRUE	FALSE
+54	Yes	514382-004238	Not Hispanic or Latino	Black or African American	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+49	Yes	10000364-6542819	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+57	No	419639-001429	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	10022779-wO1DA9tg80WVpBWEupWfmw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+58	No	10000364-1881463	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+61	Yes	10003752-L0hpxpZ602vrOMhiO816w	Not Hispanic or Latino	Black or African American	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+60	No	419639-001813	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	Yes	514382-011620	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+31	No	419639-003615	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	No	10000364-72947	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+87	Yes	10000364-1380451	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+90	No	10008204-M7wlaQiZUOcXW9REDReQ	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+88	No	10008204-haBAsmpFA0WDZHQcuxdZKQ	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+62	No	10008204-pXbkl0mpL0Wjr1BrIfgig	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	Yes	514382-003724	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	No	514382-041401	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+40	No	514382-016116	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+68	No	10008204-SjCqmDv1K02UK6L3pkiX6g	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+42	No	514382-014699	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	514382-013651	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+42	No	514382-040086	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	Yes	514382-007719	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	No	419639-000975	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+30	Yes	10003752-atkeMYhSUKYOZWwr4crZA	Not Hispanic or Latino	Black or African American	Female	"CR, CT"	TRUE	TRUE	FALSE	FALSE
+45	Yes	10022779-6Am6NYsy0m4dLN7l8wggQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	No	514382-040317	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	No	514382-040668	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+52	No	10008204-ex6ORDAEXk2qBhPAjnRFkQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+54	Yes	419639-007218	Not Hispanic or Latino	Native Hawaiian or other Pacific Islander	Female	DX	FALSE	FALSE	TRUE	FALSE
+80	No	514382-034870	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+46	No	10000364-1406272	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	514382-001826	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+58	No	10000364-1845421	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+75	Yes	419639-004520	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	10000364-6604907	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+63	No	10008204-En0LXbpcqECl4gkW4Xn3eg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+44	Yes	514382-012596	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	No	419639-010127	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+77	No	419639-009036	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+84	Yes	10003752-jYqP2dXmUuXzdgQTpTeg	Not Hispanic or Latino	Black or African American	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+1	No	10008204-7I18BPd5CEq0cSK1lunkCQ	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+28	Yes	10022779-FWvSrWCw0OWmgXRxiOxAw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+74	Yes	514382-003505	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+15	No	10000364-1525209	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+80	No	419639-006682	Not Hispanic or Latino	Asian	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+50	No	419639-005766	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	514382-003130	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+43	Yes	10000364-1916339	Not Hispanic or Latino	Black or African American	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+28	No	419639-007931	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	Yes	514382-004400	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+83	No	514382-040980	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	Yes	10022779-QYb8UvogVU2BW3DvlsdEg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	514382-014121	Not Reported	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+51	Yes	514382-000643	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+44	No	514382-014463	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	Yes	10008204-wPJrucBzi0eIfwImuJVmYA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+74	Yes	514382-001153	Not Hispanic or Latino	Black or African American	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+61	No	419639-011731	Not Hispanic or Latino	White	Female	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+42	No	514382-036297	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+77	No	10008204-FsJ8OtJTU23UWRxNN4Tyg	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+59	No	10008204-HjW2ExDuUOdREwoN4zgVA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+30	No	514382-015166	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	No	10008204-XXtDI3Mr6kyNlP4Ee6vxsQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+39	No	10008204-79wSuvDhvkuz7DsUp2VzA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+47	No	514382-035196	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+82	No	514382-040023	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+28	No	419639-002689	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	No	419639-001252	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+31	Yes	514382-007037	Not Hispanic or Latino	Black or African American	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+64	No	419639-000917	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+42	Yes	10000364-972882	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	10000364-5419040	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	10000364-5530110	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+29	Yes	514382-004384	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+32	Yes	10000364-912379	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	No	514382-018045	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	514382-003240	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+22	No	10008204-cxHgZmfF30qztbzTrclFFg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+48	Yes	514382-001766	Not Reported	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+29	No	10003752-fXnQWRAxkudrkqyIgSFag	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+64	Yes	10000364-1988357	Not Hispanic or Latino	American Indian or Alaska Native	Female	CT	FALSE	TRUE	FALSE	FALSE
+2	No	10008204-UnEBosCzkqJPcJUgIh4BA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+45	Yes	10003752-DTrQzFinECIwmpMJsC3RQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+58	Yes	514382-004999	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+88	Yes	10003752-OTLBcl1e80eyHl84UkyM1Q	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+63	Yes	10000364-1364048	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	10022779-dG4eqW1y0GZry4WZyfasA	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	419639-003417	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+90	Yes	419639-006626	Not Hispanic or Latino	Asian	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+23	No	10008204-YwZo3P03vEOgFLb8a2aNg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	No	10008204-2Gyzw89JoUqPxAgtcuhCHg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	514382-000715	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+35	Yes	10000364-1664664	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+87	Yes	419639-011426	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+32	No	419639-001679	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	Yes	419639-008307	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+55	No	10008204-x6g6eDdMLECU8CiuGZlQXg	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+58	Yes	10008204-fPg9pTGBzUWWz50rR2elg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	Yes	514382-005061	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+51	No	514382-014908	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	No	514382-039784	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+68	No	10008204-XHqpEsPoUE60MXy6OtjVqQ	Not Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+52	Yes	419639-003680	Hispanic or Latino	Not Reported	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+90	Yes	419639-006567	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	No	514382-040015	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+84	No	10008204-ItSpHLtXE0uTU9tjFaUdYg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	Yes	419639-012491	Not Hispanic or Latino	Not Reported	Female	"DX,CT"	FALSE	TRUE	TRUE	FALSE
+57	No	419639-001067	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+50	No	419639-003402	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	10003752-qbeiLndM9Ei6NeRHTLNU6A	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+65	Yes	514382-011533	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+87	Yes	419639-007237	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	No	10000364-5791525	Not Hispanic or Latino	Black or African American	Female	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+38	No	514382-015815	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+37	No	10000364-1510921	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+84	Yes	514382-009880	Not Hispanic or Latino	Black or African American	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+66	Yes	514382-005172	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+69	No	514382-036152	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+62	Yes	514382-009190	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+19	Yes	514382-013424	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	10003752-OzFq24aY3kQqvm5tVd3cA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+79	No	10000364-6504057	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+60	Yes	514382-002319	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	No	419639-010609	Not Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+68	Yes	514382-013004	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+71	Yes	514382-011471	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+86	No	514382-034594	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+73	Yes	10000364-1396360	Not Hispanic or Latino	Black or African American	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+34	Yes	10000364-5799200	Not Reported	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+75	No	10000364-1618598	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+40	No	514382-016894	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+50	No	514382-017627	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	No	419639-009327	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+52	No	10003752-IfW0NwLuUCABD52okyB6Q	Not Hispanic or Latino	Black or African American	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+77	No	514382-015984	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+89	No	419639-000028	Not Hispanic or Latino	Asian	Male	"DX, CT, CR"	TRUE	TRUE	TRUE	FALSE
+74	Yes	514382-006769	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+35	Yes	10022779-C8YaEPLdD0OkCfNc7gVOwA	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+90	No	10008204-UIQAiszcX0agDhbIWywA	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	Yes	514382-002812	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	No	10003752-rcMzXbt0GEi4OtHDMr7gg	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+890	Yes	514382-001426	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	No	419639-001418	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+90	Yes	10003752-FIgtdTAzUCbQnjwdqO1uA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+57	No	10008204-tKVw7p6Z9UOZdY5pVpwxzg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+41	No	419639-005484	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+42	No	419639-000392	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+90	No	10000364-1450451	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+10	No	514382-035922	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+53	Yes	419639-012461	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+36	Yes	10022779-R79h3O0g0On7ZGWJtcQ	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+890	No	10008204-Z9ZTctPm0OoFwheyVmvw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+82	Yes	10003752-FulUjEunx0mjzokYb3LR9w	Not Hispanic or Latino	Black or African American	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+71	No	514382-038202	Not Hispanic or Latino	White	Female	"CR,CT,DX"	TRUE	TRUE	TRUE	FALSE
+23	No	514382-033790	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+25	No	514382-015065	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+37	Yes	10022779-3CGmq8bzxUONiUFpxG5lXQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+54	No	10008204-t1yuyLFdEGUwTSTwSdYg	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	419639-010722	Not Hispanic or Latino	Not Reported	Female	"DX, CT"	FALSE	TRUE	TRUE	FALSE
+40	Yes	10000364-2000718	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+78	No	10008204-HtllImps20CK6gW9r3kB0w	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	10003752-4UESJcBziUy8o8HhBZ9Q	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+39	No	514382-040605	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	10022779-u5vEv0F2IE6Bdi5Rht5Sgg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+48	Yes	10003752-zTQi7K4lkmevW4bD0TU2Q	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+75	No	10008204-2UrPvPI7gEequJnoittKjg	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+73	Yes	10000364-900710	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+57	Yes	10000364-1451946	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+71	No	514382-037116	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+21	Yes	10000364-2098502	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+65	Yes	514382-012978	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+29	No	419639-008054	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+73	No	419639-008634	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+46	No	10008204-0mzVZBoVCkyShOdQktotw	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	419639-008124	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	10022779-nNztc4nfD0uRCm40nboiTA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+69	Yes	514382-002628	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	No	10000364-6601849	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+36	No	419639-010150	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	10000364-5877412	Not Hispanic or Latino	White	Male	MR	FALSE	FALSE	FALSE	TRUE
+36	Yes	514382-013345	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	No	419639-007909	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+25	No	10000364-731210	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+75	Yes	514382-008619	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	10003752-iMHsSjD7LUKNAriM28Biw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+63	Yes	10000364-2708292	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+81	Yes	10000364-6505023	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+78	No	10000364-6527712	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+86	No	10003752-isaN06wv0rWQLte2W2tw	Not Hispanic or Latino	Black or African American	Male	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+73	Yes	514382-012685	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	10003752-EkKTL49uWkyk0ccUufe5A	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+38	Yes	514382-012533	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+29	No	514382-035079	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+59	No	10000364-2394549	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	10000364-507869	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+50	Yes	10000364-5453930	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+59	No	419639-004187	Not Hispanic or Latino	Not Reported	Female	CT	FALSE	TRUE	FALSE	FALSE
+69	No	514382-036822	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+85	Yes	514382-006986	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+30	Yes	514382-007430	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+26	Yes	514382-001060	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+69	Yes	514382-004397	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+39	Yes	10022779-arYzLWONFkO8dKs1ppuSAg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+84	Yes	419639-000959	Hispanic or Latino	Not Reported	Female	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+36	No	419639-001562	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+44	No	514382-041049	Not Hispanic or Latino	Asian	Male	CT	FALSE	TRUE	FALSE	FALSE
+68	No	10003752-M1NT0lb6UWK4rnqsiP2Kg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+74	No	10000364-459089	Not Hispanic or Latino	Black or African American	Male	"CR, DX"	TRUE	FALSE	TRUE	FALSE
+64	No	419639-001495	Not Hispanic or Latino	Black or African American	Male	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+90	Yes	10000364-6083570	Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+59	No	10008204-AWAvNGa5k6ANEdVIJMg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+68	No	10008204-2txmkL2lbECuoJH4jOyw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+66	No	514382-034275	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+45	Yes	514382-003303	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	No	514382-035860	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	No	419639-009623	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	No	514382-038176	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	419639-010501	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	No	514382-017515	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	Yes	419639-009533	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	514382-002846	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+40	No	514382-016328	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+30	No	514382-036198	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+86	No	419639-000015	Not Hispanic or Latino	Asian	Male	"CR, DX"	TRUE	FALSE	TRUE	FALSE
+59	No	419639-012593	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	Yes	10008204-mIJHsPpIdkyQJ3o93YI6wg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+30	No	514382-018073	Not Reported	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+90	No	419639-004460	Not Hispanic or Latino	Native Hawaiian or other Pacific Islander	Female	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+68	No	514382-035109	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+29	Yes	514382-000593	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+35	Yes	419639-010526	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	No	514382-015291	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	No	514382-014994	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	Yes	10000364-981985	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+55	No	514382-036730	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	Yes	419639-012560	Not Hispanic or Latino	Other	Female	CT	FALSE	TRUE	FALSE	FALSE
+44	No	10000364-5863631	Not Hispanic or Latino	White	Female	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+21	No	514382-035354	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+81	No	514382-036974	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+38	No	419639-001002	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+69	Yes	10003752-Dny4zgsS06TvrZFcquA4Q	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	Yes	514382-008971	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+29	No	419639-003020	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+73	Yes	10000364-5227760	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+32	No	419639-008262	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+76	No	419639-005293	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	Yes	10000364-6610320	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+21	No	514382-018094	Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	514382-006377	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+82	Yes	10000364-1613276	Not Hispanic or Latino	Black or African American	Male	"CT, MR"	FALSE	TRUE	FALSE	TRUE
+51	Yes	419639-010522	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	Yes	514382-004366	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+51	No	419639-001160	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	No	10003752-l7eVYIhzd0y1tal6sbyUAw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-038070	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	514382-002612	Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	10003752-iXEjxXpxfkKopbEO9ehM1Q	Not Hispanic or Latino	White	Male	"CR, CT"	TRUE	TRUE	FALSE	FALSE
+80	No	419639-001182	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	10008204-q1ry5pyCjkamkK1HSQKzLA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+46	Yes	10022779-v1GX9kIemkW7XBTcZcVOQQ	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+49	No	514382-041540	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	Yes	10000364-1491547	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+77	Yes	10008204-p5z60TdbESd02kQNLL53g	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+76	No	10008204-oVkFEe0QekaJkqJP1zAvg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+42	No	419639-000203	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	No	419639-011470	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+67	No	10008204-tJdGV8Ir0EmDzLEGv8Vxg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+27	Yes	514382-008815	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+88	Yes	514382-012068	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+48	Yes	514382-011261	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+48	No	419639-011025	Not Hispanic or Latino	Not Reported	Female	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+32	No	419639-004783	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+76	Yes	10003752-HwjAv0ro9k2srOgPyc1y2w	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	No	514382-015413	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+88	Yes	514382-001574	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	Yes	514382-005099	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	10000364-2394851	Hispanic or Latino	Not Reported	Female	CT	FALSE	TRUE	FALSE	FALSE
+69	Yes	419639-012579	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	10022779-A6mQC1KKw0CGkvJIpjlotA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+34	Yes	514382-008729	Not Hispanic or Latino	Black or African American	Female	"CR,CT,DX"	TRUE	TRUE	TRUE	FALSE
+58	No	419639-006138	Not Hispanic or Latino	Asian	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+44	No	10008204-EA3LBkYekaOXNRJEDq9pQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+62	Yes	10003752-jXmO3fRVZEOxwbzvPSuxA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+45	No	419639-009995	Not Hispanic or Latino	Not Reported	Female	"DX, CT"	FALSE	TRUE	TRUE	FALSE
+890	No	10008204-mEhy8uCAAUy9Ns5EkWObQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	514382-013862	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	No	419639-011343	Not Hispanic or Latino	Asian	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+39	No	419639-009720	Not Hispanic or Latino	Not Reported	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+60	Yes	10000364-1510279	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+46	Yes	10022779-wDiOP6w4uEWC74ww2hWMGQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+23	Yes	10022779-v8ZIzcvGxEOfq3I2ux7onA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	No	419639-004916	Not Hispanic or Latino	Other	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+31	No	10000364-1433476	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+26	No	514382-017972	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	No	10008204-P0DigKcEoUybUmvlHuAOrg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+79	No	514382-035509	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+58	No	514382-034830	Not Hispanic or Latino	Black or African American	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+65	Yes	10022779-izo4x9hamk272ypto3iRcw	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+71	No	419639-003963	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+38	Yes	514382-006022	Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+81	No	419639-005555	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+50	No	514382-040860	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+71	No	514382-039712	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+890	No	514382-036154	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+72	No	514382-036437	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+80	No	419639-000636	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+75	Yes	10000364-1588060	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	No	10003752-PpQUHjFObEK9wqflGOT6Ig	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+28	No	514382-036716	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+67	No	419639-000822	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+33	No	419639-000133	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	514382-001888	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+15	No	10000364-6427498	Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	No	419639-000351	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+6	No	10000364-2616385	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+49	No	419639-004763	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	No	514382-038688	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	514382-008355	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	No	419639-005181	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	10008204-mfKixKc4Wk2bHsn6XIXtXA	Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+35	No	10000364-1568046	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+81	No	10008204-cOpOoSaLWkqu2VhzWvhBFA	Not Hispanic or Latino	White	Female	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+29	Yes	10000364-1013265	Not Hispanic or Latino	Black or African American	Female	"DX, CT"	FALSE	TRUE	TRUE	FALSE
+22	No	10000364-999155	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	10000364-5225747	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+54	No	514382-034097	Hispanic or Latino	Other	Male	CT	FALSE	TRUE	FALSE	FALSE
+56	No	10000364-5872608	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+86	No	10008204-y08fDh5PGEqc1vrjSWS1w	Not Hispanic or Latino	White	Male	"CT,CR,DX"	TRUE	TRUE	TRUE	FALSE
+63	No	419639-002023	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+32	Yes	514382-003418	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	No	10008204-nBUwe3f6U2fJDXPexAehg	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+69	No	419639-005621	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	10000364-5479900	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+74	No	514382-040309	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+24	No	419639-011325	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+73	No	10008204-KsK2AFQVEOLJkYjsRkEiA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+32	Yes	514382-002514	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	No	10008204-V9VMS0cn7Um7pRjJfxTGmA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+82	No	514382-036311	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	No	419639-000074	Hispanic or Latino	Not Reported	Female	"DX, CT"	FALSE	TRUE	TRUE	FALSE
+89	No	514382-015223	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	514382-008508	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+73	Yes	10000364-5891347	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+43	No	419639-002296	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+25	No	419639-008010	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+71	No	419639-010849	Not Hispanic or Latino	Not Reported	Female	"CT, DX"	FALSE	TRUE	TRUE	FALSE
+57	No	514382-037081	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+73	No	10000364-1015982	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+83	No	514382-014754	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	Yes	10003752-GvYisQqnEKZNt9q3Yue8A	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	No	419639-011017	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	419639-012400	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	514382-040504	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+78	No	10008204-KSDPpfVtAUmCoZ3C1evloA	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+40	No	10008204-3ES84tRJF0WTkK2dXlLdUA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+73	No	10000364-5972340	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+44	No	10008204-SvC00D2RdkiIRP5zTELOdw	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	No	514382-015245	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+86	No	10000364-261165	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+79	No	514382-038756	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+32	Yes	514382-007605	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+25	No	419639-011023	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+42	No	10008204-2jgvVv2SZku9wKxaC4wlA	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+59	No	419639-000682	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+82	Yes	10000364-2434739	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+76	Yes	10000364-203144	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+87	No	10008204-5b35eO7n5EaagPhQuMCUFg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	No	514382-035565	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	10003752-DBwTvjPHZUWEz0KkyDTnTQ	Not Hispanic or Latino	Black or African American	Female	"CT, CR"	TRUE	TRUE	FALSE	FALSE
+19	Yes	419639-009676	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+37	No	514382-034419	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+28	No	10003752-nsbNmvZh8kKuqb6L4k7Cdw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+72	No	514382-036579	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	514382-010398	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	514382-007846	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+72	Yes	10000364-204358	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+57	Yes	514382-005751	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	No	10008204-w4EQuUrKPEKgeB1oQWSAg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+60	Yes	514382-007870	Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+31	Yes	10003752-HBcJLVnSn02nXjcg9LnYyw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	No	419639-009398	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+27	No	419639-002245	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+23	Yes	514382-004490	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+89	No	514382-038040	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+74	Yes	10022779-H20rH7scaEmrZA0NebCKvQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	No	514382-041238	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+56	Yes	10000364-1647020	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+75	Yes	514382-001405	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	Yes	514382-005688	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	No	514382-037111	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	No	10008204-Beruz5Khw0efs2V4VzpSQ	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+80	No	514382-035068	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+77	Yes	10000364-6555516	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+44	No	419639-007261	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+69	No	514382-038877	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+67	No	419639-000474	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+85	No	10008204-oD72gk0Mfk66f27e7CL5SA	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+28	No	514382-014356	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	Yes	10008204-AXhzyz2340e6IpXLYDFzDA	Not Hispanic or Latino	White	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+21	Yes	10022779-Lqu5dz45GkWocxSyuQUboA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+27	Yes	514382-005719	Not Reported	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	Yes	10022779-jJ7YPgSmEKdvrRpSoyEKw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+46	No	514382-041357	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+50	Yes	10008204-fdWy6BqIUUqffLNt2inOwg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+68	No	419639-009006	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+69	No	10000364-5953874	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+82	Yes	514382-012932	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+73	Yes	10003752-PWS9SCizWkO7LotLU6lw	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+62	Yes	419639-011639	Not Hispanic or Latino	Not Reported	Female	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+65	Yes	10022779-6nW50JoVfEyidI9slS5MYg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+54	Yes	514382-000197	Not Hispanic or Latino	American Indian or Alaska Native	Male	CR	TRUE	FALSE	FALSE	FALSE
+74	No	10000364-121522	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+56	No	10008204-k0j4UeDbI0SHtSJfpgbOFg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+82	Yes	10000364-1543883	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+61	Yes	514382-007419	Not Hispanic or Latino	Black or African American	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+22	Yes	514382-002885	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+77	Yes	514382-003499	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	No	10008204-cRowmxiEqpSea0ALBQOg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	10000364-467364	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+21	No	10008204-a072nyBO50CEEWjD8t6oQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+77	No	514382-014770	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+16	Yes	10022779-KxMXVgijqEaf8MZTNAvQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-038156	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+53	No	419639-002341	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+22	Yes	419639-009485	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+33	No	419639-002107	Hispanic or Latino	Not Reported	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+74	No	514382-035900	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	514382-008155	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+79	No	514382-015574	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+37	No	419639-003826	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+64	No	419639-000479	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+11	No	10022779-kSg6HuaTj0UKUR8tU7GVw	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	10003752-tM5zNohaUiqAoNMijvw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+29	Yes	514382-008428	Not Hispanic or Latino	American Indian or Alaska Native	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	No	419639-008064	Not Hispanic or Latino	Asian	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+40	Yes	10000364-5600044	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+65	Yes	10003752-KLXAugTqES6yC6NMOYbMQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	Yes	514382-002308	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+86	No	419639-004523	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	10000364-1792402	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+33	Yes	10003752-aoA9JtjgE6mpUsVsIGWcA	Hispanic or Latino	White	Male	"DX,CT"	FALSE	TRUE	TRUE	FALSE
+45	Yes	10003752-uEiLXGW4rU2HxvMawC0hw	Not Hispanic or Latino	Black or African American	Female	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+35	No	514382-015103	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+26	Yes	10003752-sR3IGBFa30Wv2WAKiBivg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+44	Yes	10000364-6562332	Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+52	No	514382-015255	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+73	No	514382-017321	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+31	Yes	419639-009859	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	Yes	10000364-1664253	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+40	No	10000364-1988017	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+59	Yes	10000364-5767865	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+66	Yes	10022779-MsJkcmQjv0yfTGNV9yE0Bg	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-037601	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	Yes	10022779-RsZUDUoGXkO19ls1fVVkcA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	No	419639-001747	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+88	Yes	10000364-888308	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+36	No	419639-011252	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+81	Yes	514382-001312	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+43	No	419639-002783	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	10008204-fj2UXXRSUGfDKWQdm1Ug	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+56	Yes	10008204-Y2xnQ5LEU2FLvH4XbLVlg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+24	Yes	10022779-qLTaEI5ALk29rBESgLr4g	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+47	Yes	10000364-250300	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+78	No	514382-037618	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	No	419639-011710	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+36	No	419639-000816	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	514382-015918	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+24	No	514382-034060	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	419639-011262	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+77	Yes	10022779-GMkNMeR5KEiYlVLzllcbVA	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+65	No	10008204-Uo2Lai3mX060MeT3h98MbQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+30	Yes	10003752-Z1Ut1OAEH0GukJRIaX2vtw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	10008204-RpoL4LErx0G1EQBqXbakg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	No	514382-037479	Not Reported	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+85	Yes	514382-008325	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	514382-006427	Not Reported	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+29	No	514382-037237	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+61	Yes	514382-001753	Not Hispanic or Latino	Native Hawaiian or other Pacific Islander	Male	DX	FALSE	FALSE	TRUE	FALSE
+30	No	419639-011724	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+77	No	514382-033840	Not Hispanic or Latino	Native Hawaiian or other Pacific Islander	Male	CT	FALSE	TRUE	FALSE	FALSE
+43	Yes	514382-007831	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+40	No	419639-002812	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	No	419639-003092	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+43	Yes	10008204-tvLY0a63CkiclBnjVM4qqw	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+60	Yes	10000364-1813332	Not Hispanic or Latino	White	Male	"CT,CR,DX"	TRUE	TRUE	TRUE	FALSE
+88	No	10008204-mkw7AsA66UqIKRaS9qVFbA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+43	Yes	419639-012605	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	514382-005411	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+38	No	419639-007923	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	No	10022779-k0RSq0HsPkuOtEW4Xf0h0Q	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	Yes	514382-014275	Not Reported	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+40	No	10003752-TpQRU6impECqZPa3lv3pbQ	Not Hispanic or Latino	Black or African American	Female	"CR, CT"	TRUE	TRUE	FALSE	FALSE
+69	No	419639-002336	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	514382-035808	Not Reported	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+40	Yes	514382-005016	Not Hispanic or Latino	Asian	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+76	No	514382-036794	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+36	No	514382-039292	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+74	Yes	10008204-tr7Ev7zwc0ubpwWswDbVag	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+77	No	419639-011085	Not Hispanic or Latino	Not Reported	Female	"CT, DX"	FALSE	TRUE	TRUE	FALSE
+29	No	10003752-mpcx0we0jESOdf8FK6q7VQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+30	Yes	10000364-1584234	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+52	No	514382-035004	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+68	No	10008204-ol1Uc6133kOUDRRv3wwR7g	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+51	No	514382-036343	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+45	Yes	514382-014107	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+87	No	10008204-ZJ9e4SqbEilPykF3hBVLQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	No	514382-035549	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+85	Yes	10000364-4953211	Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+31	No	10008204-kLmYB6YGEWrjTjiF24WEQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+67	Yes	514382-004158	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+74	No	419639-005189	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+46	No	419639-010853	Not Hispanic or Latino	Not Reported	Female	"CT, CR, DX"	TRUE	TRUE	TRUE	FALSE
+59	Yes	10000364-1006408	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+23	Yes	419639-012308	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+46	No	419639-003398	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	514382-011728	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	514382-011323	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	514382-003624	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+37	Yes	514382-010875	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+54	No	10000364-5302644	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	10000364-1168531	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+68	No	10008204-p4z0jCS6U6Nf03YMc2zdA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+68	No	419639-004276	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	No	10008204-x1pHLevCOEKwlah7eC6pg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+38	Yes	419639-011968	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+80	No	10000364-32021	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+78	Yes	514382-001846	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	514382-012070	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+66	No	10008204-OcLDcorCUuM9pvR3ZsRw	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+57	No	419639-008178	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	514382-002736	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+51	Yes	10000364-5468517	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+48	Yes	514382-012099	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	No	419639-006256	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+68	No	10008204-3kuTVnUUJUSqcOAwVFYVJw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+30	No	10000364-1956259	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	No	514382-015633	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+89	Yes	514382-009674	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+50	Yes	514382-010924	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+55	Yes	514382-011123	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+80	Yes	514382-006661	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	10000364-1928253	Not Hispanic or Latino	Black or African American	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+20	Yes	10022779-FnLHshir90CaGvYJfmIzRQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+78	Yes	10022779-LtCwU31sUOrndIMk9Cy4A	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+26	No	10008204-DRQfyBUnEyqgU3BtZqQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	10000364-1431161	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+62	Yes	514382-006879	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+52	Yes	514382-006784	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	10000364-1732728	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+70	No	419639-001436	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	10022779-y6u17yXKUGnREDVtVOvnQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+42	Yes	514382-013325	Not Hispanic or Latino	Asian	Male	CT	FALSE	TRUE	FALSE	FALSE
+890	No	10008204-JnBDrDUT0W9OBlgMy7OQ	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+87	No	10000364-592858	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+77	Yes	10000364-1327359	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+63	No	514382-016713	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+40	Yes	10000364-1599703	Not Hispanic or Latino	White	Female	"CT, DX"	FALSE	TRUE	TRUE	FALSE
+75	No	10008204-RAX94iVoUOwO3zdikNOog	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+46	No	10000364-5737391	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+50	No	419639-002529	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+52	Yes	514382-001386	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+78	No	10000364-1777380	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	No	10000364-1727322	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+51	Yes	10000364-5208152	Not Hispanic or Latino	Black or African American	Male	"CT,CR,DX"	TRUE	TRUE	TRUE	FALSE
+69	No	10022779-PrndITr340Ce2JguYbnlFA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	No	10022779-5IfQhhUN0udLO0mOvp20w	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+87	No	10008204-JL53ZW8xl0qHBniNX7sXBA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+84	No	419639-004112	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	10000364-6594854	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+74	Yes	10000364-5232491	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	Yes	10000364-6570129	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+51	Yes	10003752-KwOZ0dxAu0uBmAW9scWMlQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	No	514382-035630	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	No	514382-040991	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+26	Yes	10022779-FvrFuM1SaEOzU7le8Wbj4g	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+54	No	10022779-ZojXJU1YbkKhwZO7N534A	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+81	No	514382-014669	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+36	Yes	10000364-2689811	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	514382-011478	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+44	Yes	10022779-djMNV4egfkO5jhRNUkQZHw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+28	No	10008204-999tC5jC3UafypQKjj3tjg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+39	Yes	514382-012075	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	514382-010135	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+64	No	10008204-gwAhXcRyPkqkaPwZPKnK8Q	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+890	Yes	514382-011718	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	Yes	514382-005181	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+32	Yes	10022779-V80CXNphBE2q0QxggH9ow	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+74	Yes	514382-013495	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+35	No	419639-000910	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+65	Yes	514382-011163	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	No	10003752-gxbvm8keQkKPhXpbHo8GQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+77	No	514382-035745	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+83	Yes	10008204-PzRECXcf0uKVZGLITT7rw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+19	No	10000364-6053860	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+75	Yes	514382-013982	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	No	10022779-nydYVgLK9EiASausNoRsA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+73	Yes	10003752-UszXJA1p0aoJeI1xjr9RQ	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+65	Yes	514382-005313	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	514382-001038	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	514382-009837	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+71	No	514382-039017	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+23	No	419639-011198	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+22	Yes	10003752-jMJrZene0kWRTPFxRAg8pw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	10022779-DVwMA0lw40uO8sFeFtflKg	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+34	No	10022779-Fta73y99EaxPmkdkQFnZQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+76	No	419639-000363	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+64	Yes	514382-001152	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+56	No	419639-001462	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+84	Yes	10000364-5302807	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+66	Yes	10003752-JZii10wSyEODoIwPX9ZOGw	Not Hispanic or Latino	Black or African American	Male	"CR, CT, DX"	TRUE	TRUE	TRUE	FALSE
+45	Yes	514382-003413	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+31	Yes	514382-000516	Not Reported	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+33	Yes	10022779-6u9RRINmE6ECuxNylFq9w	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+13	Yes	10000364-5298654	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+46	Yes	10000364-1775416	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+59	No	514382-018144	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	10000364-6033864	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+48	No	10008204-5JDpxSdokei03XSKBqBtQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+75	Yes	10003752-kR4qTINpIkqtQaQg0wUSxw	Not Hispanic or Latino	Black or African American	Female	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+31	Yes	10022779-5SmuUryiD0GI5V7ZOMrNDg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+72	Yes	10022779-ZDgiH9OBI0veunNyXzdQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+77	Yes	10008204-dKVE3fIXrkeEl9OfEMb7g	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+48	No	419639-007433	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+48	No	10008204-AkPpPtgksUmlQmJ0GDiGA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+79	Yes	514382-002568	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+33	No	419639-000434	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+72	No	419639-011879	Not Hispanic or Latino	Not Reported	Male	"DX,CT"	FALSE	TRUE	TRUE	FALSE
+90	No	419639-008202	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+68	No	514382-038829	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+51	No	419639-002238	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+71	No	10008204-o6VUXotVAkOgdNObuc6uPQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+48	No	419639-003357	Not Hispanic or Latino	Native Hawaiian or other Pacific Islander	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	10000364-2609047	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	No	10000364-1336374	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+60	Yes	514382-000480	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+85	Yes	419639-010805	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+77	Yes	10000364-6524298	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+26	Yes	10003752-Dskh29qofEKSJk1LTbEnHw	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+29	No	419639-003734	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+38	No	514382-015940	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	419639-008063	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+39	No	419639-002330	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+86	Yes	10000364-5575781	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	No	10000364-1834582	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+61	No	419639-004901	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+32	No	419639-000431	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+51	Yes	514382-003310	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+49	Yes	514382-002633	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+37	Yes	514382-010647	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	No	419639-004341	Not Hispanic or Latino	Native Hawaiian or other Pacific Islander	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	No	10003752-V3vnWOkkfUydTFk8kpMHkA	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+49	Yes	10000364-104361	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+71	No	419639-009749	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+79	No	419639-006490	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	No	10000364-2459280	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+34	No	419639-010299	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+77	No	419639-011549	Not Hispanic or Latino	Not Reported	Male	"DX,CT"	FALSE	TRUE	TRUE	FALSE
+56	No	419639-005334	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+22	No	419639-010563	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+35	No	419639-003282	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+23	No	419639-005020	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+32	No	419639-011716	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+52	No	514382-039505	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	514382-003957	Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+27	No	419639-008248	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	No	514382-039786	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	No	514382-039758	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+51	Yes	514382-000215	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	No	10008204-oW9JFdtgJ0iNfUhIoRIew	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+42	No	419639-008240	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+46	Yes	419639-002372	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+52	Yes	10000364-2685234	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+53	Yes	10022779-WqifjuoIUWRAwdJczZA	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+48	Yes	10022779-KPHRvrQlGEuUbzwaFNhzCA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+75	No	514382-038315	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	No	514382-037716	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	No	10008204-9omnk3kzM0ix8hz43533XA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	No	419639-003468	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+59	Yes	10000364-2382878	Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+60	No	419639-010295	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+83	No	10008204-uO9qUs9REmHFq2MqB5DWQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+87	No	10008204-D8VS2USZQkaeQ1Xlv9OWcQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	514382-000420	Not Hispanic or Latino	White	Male	"CR,CT,DX"	TRUE	TRUE	TRUE	FALSE
+54	Yes	514382-011752	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	No	514382-014457	Not Hispanic or Latino	Black or African American	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+890	No	10008204-8VVFTtDTdEW2lau5yLBUxg	Not Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+29	Yes	10022779-HuulC32aj0imAW71oLB79g	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+83	No	419639-000738	Not Hispanic or Latino	Asian	Male	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+89	No	10008204-jSFvSz5vJESObzURE7dq7w	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+70	No	10008204-J65fJAyE30yY9Wx7IOZzRw	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+78	Yes	514382-010590	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+41	No	10008204-kEnx7DxmEyzaLULmcCww	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+76	No	10008204-YE22n76vhkCTcPU9ZJxqtQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	Yes	514382-002958	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+890	No	514382-038081	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+23	Yes	10000364-6610991	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+81	Yes	10000364-6635668	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+56	Yes	514382-008784	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+30	No	10008204-XKnhRT833kaiFohXdvSsRw	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+85	No	514382-038322	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+59	No	514382-016445	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	No	10008204-xenOULLb60miJFSbDLxvMw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	Yes	10008204-PgF7HZhaI0mIfX8rznYSIw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+31	Yes	419639-010999	Not Hispanic or Latino	Not Reported	Male	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+54	No	514382-017323	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+73	No	514382-035595	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+29	No	514382-037761	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+77	Yes	419639-012307	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	514382-008087	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+79	Yes	10022779-JE90CoMiLkGRC2uDR5IfMQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+46	Yes	514382-000168	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+19	Yes	10022779-7xmzKriZU2xQq4E5HtVA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+40	Yes	10022779-QVvxLizi00SpeA24sEX4g	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+48	No	514382-037012	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+37	No	419639-005114	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	514382-013287	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+85	Yes	10000364-223945	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	No	419639-010075	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	No	419639-000584	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+73	No	10000364-1519713	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+58	Yes	514382-001458	Not Hispanic or Latino	Black or African American	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+86	No	10008204-oR2NwVQtNEeWne0xRsLqg	Not Hispanic or Latino	White	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+54	Yes	514382-006778	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+74	No	419639-000554	Not Hispanic or Latino	White	Female	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+65	Yes	10000364-5371600	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	No	514382-015601	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+78	Yes	10008204-CKxXxA9M0SEgAspmKfyw	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+55	No	10008204-J9NpLCCWEODdZ63L7Rr5A	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	No	419639-007287	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	419639-005620	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+67	No	514382-038826	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+37	Yes	514382-011871	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	514382-008258	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+33	Yes	514382-001281	Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+88	No	419639-011649	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	No	10008204-N0hDbHsyQ0aUp5W93tH0Q	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+90	No	10003752-tZ2FWhnSYE6Kx67hdgQWqg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-038592	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	Yes	10000364-5758463	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+41	Yes	10003752-L2RZlOZykurCMBBfVoWaA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+84	No	514382-015925	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	10022779-UuGxshlmjECosDW3qgxzw	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+38	Yes	10000364-1345532	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+84	No	514382-015595	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+45	No	419639-002180	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+63	No	419639-006735	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+77	No	10008204-BKsHCE9P60isoisZTnkuaA	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+79	Yes	10000364-1443040	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+47	Yes	10022779-8yIgzNjwukW8CLVu1mTsg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+7	Yes	10003752-DjT09WKmHUmph8qhwBbv3g	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+46	No	419639-011519	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	419639-004729	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+52	Yes	514382-001109	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+86	No	514382-016885	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+74	No	419639-000076	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	514382-003555	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+64	No	10000364-887709	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	514382-013225	Hispanic or Latino	Other	Male	CT	FALSE	TRUE	FALSE	FALSE
+17	Yes	514382-006304	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	419639-010660	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+40	Yes	10003752-rsl9CXNGTkGYz9EmjmszOA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+48	Yes	10022779-FWZdgqBq7USwSvcfRcXcg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	Yes	514382-011257	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+82	No	10000364-820975	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+87	No	514382-038824	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	10003752-pOGBposOJ0uZdRCT2zA6JA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+45	No	514382-040868	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	10022779-6Yp2zpA5kStV2U5UEMfMQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+54	No	514382-036295	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+69	No	514382-016789	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	514382-001898	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+42	No	10000364-5439827	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+64	Yes	10003752-OCwIjQHBkO0uZL95tXOA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+42	No	514382-015268	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+30	Yes	10022779-JloT60LVXkmJE3Av9JkShQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+86	No	10008204-eu8FXTyUXEukFsMR5To6oQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+27	Yes	10022779-pJTe9jSg00iZC1B6ine1aQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+75	Yes	514382-004075	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	No	10003752-IUsYujykMUSCOsYQ94LDkA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+53	No	514382-036459	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+68	No	10008204-jpep6L29ETAtt87XCsBA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-014958	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+74	Yes	514382-007853	Not Hispanic or Latino	Asian	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+62	No	514382-039323	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+1	Yes	10003752-vi1Iyp49V0zUjKRnEhZQQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+86	Yes	514382-001138	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+71	Yes	10003752-uQLYWC7b6UyhNi9dGku8kA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+71	No	10000364-1103183	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+63	Yes	10000364-414270	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+63	No	514382-016231	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+88	Yes	10008204-zCtoWKtPY06RIaOoulVT1g	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	No	10003752-LrgvEHzp0ePs8gZjpaQ	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+55	No	419639-006449	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+45	Yes	514382-002383	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	10022779-7u8o9e7ZEuOYjoTt02Sg	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+51	No	419639-001261	Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+21	Yes	10008204-vTJUG6oCJEeyol2EOpXSg	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+90	Yes	10000364-1329883	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+33	Yes	514382-008671	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+88	Yes	10022779-4g2k3hdBMUexLC9MB1CMkA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+73	No	10008204-hKi2Ib3u0eVTxatE45arA	Not Hispanic or Latino	White	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+81	Yes	10000364-234749	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+20	Yes	10022779-howpxxSFREGKvGZm2VlUYQ	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+62	No	514382-040741	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+22	No	10000364-1208278	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	No	514382-018163	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+12	Yes	10000364-1558440	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+20	Yes	514382-012096	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+88	No	10008204-gE4IABS2IU2HMydzDwL6nQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	Yes	10000364-6589072	Not Hispanic or Latino	White	Male	"CT, CTPT"	FALSE	TRUE	FALSE	FALSE
+74	No	514382-017994	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+69	No	419639-009274	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	No	10003752-eprXQN2exUizYJbsiLjsw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+65	No	10008204-UuMjsrUhKEuOcqAxEi1kpg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+79	No	514382-040394	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+71	No	514382-037323	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	10000364-1138397	Hispanic or Latino	Not Reported	Female	CT	FALSE	TRUE	FALSE	FALSE
+43	Yes	10008204-mDMO8ZLWZUawUlYEOX9QYg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+43	No	10008204-hEjffSHYgEq9QCbKDZT7TA	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	10003752-sF8PFE7FSUGcT8uDAmvToQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+73	Yes	419639-004459	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+75	No	514382-036614	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	10000364-601680	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+58	No	514382-040361	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+67	No	514382-038114	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+50	No	419639-009472	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+30	Yes	514382-010546	Not Reported	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+83	Yes	514382-011834	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+34	Yes	419639-006808	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+75	No	10000364-1233965	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	514382-010131	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	No	514382-015207	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+38	No	419639-001938	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+28	No	419639-009099	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	10008204-ZstXvsGAAUkEED55xA94g	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+67	Yes	514382-010790	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+48	Yes	514382-010776	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+67	No	10008204-6fNsPNNNS0K4ZsmsKWi1vw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+82	No	419639-011876	Not Hispanic or Latino	Not Reported	Male	"DX,CT"	FALSE	TRUE	TRUE	FALSE
+71	Yes	10000364-2364702	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+76	Yes	10003752-NSSPdBTuKUqxpX7YL7HKHQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+23	Yes	514382-003893	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+39	No	10008204-AAXCHN6RQUmI2ETY2dU9dg	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	10022779-hyGyrWkraEyaK3qYL4l05A	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+78	Yes	10022779-Gq6qFSl1zkGUa5LL9fPX5w	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	419639-010516	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+81	Yes	514382-004492	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	10000364-6333111	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+890	No	514382-014713	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+35	No	514382-036068	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+29	No	10008204-UQCZ6b2ND0GIvdS2nQj6HA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+23	Yes	514382-008345	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	10003752-A8dkYkH5C0is2OvEbv0IPA	Not Hispanic or Latino	Black or African American	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+45	No	419639-003903	Not Hispanic or Latino	White	Male	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+41	Yes	10000364-1923213	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+65	No	10003752-fYK6rJrRkCd0jLM2bCN6Q	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+81	Yes	10022779-gRIfADgrUybhe9LGFvew	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+52	Yes	514382-009550	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	514382-005576	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+84	No	10008204-r8poxqdUyP9FomgyNtg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+38	No	514382-007668	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+37	No	419639-002876	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	No	514382-036143	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+69	No	10000364-1302856	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+29	No	514382-036171	Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+34	No	514382-017043	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	514382-011381	Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	Yes	10022779-wWUTYfliUF3SKW8oONw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+52	Yes	514382-005074	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+40	Yes	10000364-1175659	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+31	Yes	419639-008764	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+47	No	514382-034640	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+33	Yes	10008204-ajS1m7j23kuC7AKVQyeg	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+41	Yes	419639-012497	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	514382-004271	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+58	Yes	10000364-1595036	Not Hispanic or Latino	Black or African American	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+66	Yes	10003752-nMCk1mlhUi6eGnjtHF5kA	Not Hispanic or Latino	Black or African American	Male	"CR, CT"	TRUE	TRUE	FALSE	FALSE
+71	No	419639-000047	Not Hispanic or Latino	Asian	Female	"DX, CT"	FALSE	TRUE	TRUE	FALSE
+51	Yes	419639-006589	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+69	No	10000364-2412244	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+26	Yes	10000364-1588638	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+2	No	514382-015873	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+890	No	514382-015008	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+37	No	10008204-vonssC4J8ky8DEJJVQCGQg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+85	Yes	10008204-dEjAqBe9dEKF3HrW4tHBQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+33	Yes	10000364-1491780	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+32	No	514382-017639	Not Reported	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	No	419639-011504	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	No	514382-035886	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+78	Yes	514382-003221	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	514382-011731	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	10000364-5874693	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+78	Yes	419639-008607	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	No	10008204-3PjzEUHD3UuEYGSyYFI9rw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+66	No	10000364-310267	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+41	Yes	10022779-R4xXlVQmEES82nxI46NtA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+43	Yes	10008204-6meBitdF0qJEHg6awFZDQ	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+24	Yes	514382-005115	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+17	Yes	514382-003051	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+82	No	419639-002807	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+45	Yes	10000364-1882460	Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+45	Yes	10022779-jbKbGk2oEUypX3HG3RNbeg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+43	No	10008204-O6i2KVfW0uZjKTfhAbDvw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+83	No	419639-002061	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	514382-036802	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+79	Yes	514382-002080	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	10008204-F2gAitQmUmCk6MFEM7mpg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+29	No	514382-034272	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	No	514382-034414	Not Hispanic or Latino	Black or African American	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+61	No	419639-008820	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+77	Yes	10000364-1430178	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+67	No	10000364-6570151	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+79	No	514382-034075	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+37	Yes	514382-007588	Not Hispanic or Latino	Black or African American	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+48	No	10008204-HkEQXegV0GkdBnD3Y2p0w	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	No	514382-016420	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	Yes	10022779-zNi20NrjakZV4lcXCnLCg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+71	No	419639-002836	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+32	Yes	10022779-I4kC5RzGO0KfQDTEQToySg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+56	Yes	514382-013380	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+88	Yes	514382-012445	Not Hispanic or Latino	Not Reported	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+890	No	514382-035325	Not Hispanic or Latino	Black or African American	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+57	Yes	10022779-tw7tacIczkCydtTVALnGw	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+68	No	514382-034597	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+74	No	514382-037521	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+50	No	10008204-WjJBcive0KwA0WPc1YHw	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	No	514382-041391	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	514382-004815	Not Reported	Not Reported	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+30	Yes	514382-000768	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+28	Yes	514382-005410	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+60	Yes	10022779-4YsiyHdiES8E9je0C1S6g	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	514382-011258	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	10008204-q3v2I2mC0uf01wVCqjWA	Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+33	Yes	10003752-WuqI0PlBJkO3ST75FF1aJQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+40	No	419639-002906	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+8	Yes	10000364-1807066	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+25	No	419639-006451	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+33	Yes	514382-006959	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+24	Yes	10003752-fOMkApHHfEqKmONlM3hVdg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+6	Yes	10003752-UhI2J9v6wkG5X2U3ClZQsQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+67	No	514382-017953	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	No	10008204-wyntxUXN2Ee1LmlufRUNJQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	10000364-1382279	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+42	Yes	10022779-WeDHt5tnz0y3D1VpYswKbw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+72	Yes	10022779-SmQYoIkCdU6vQiMpWi8XYg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+75	Yes	514382-009369	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+53	Yes	10000364-1318352	Not Hispanic or Latino	Black or African American	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+72	Yes	514382-008557	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+59	No	419639-002579	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+68	No	10008204-wgoNz77YkCc3ZWo5aMpMw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+45	Yes	514382-013743	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	514382-013723	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+64	No	514382-036298	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+42	Yes	10022779-9hO0WhUyRk63wZYdQms71g	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+63	Yes	10022779-3kBYtRcyk2nPbwvXyO5aw	Not Hispanic or Latino	Black or African American	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+57	Yes	514382-000123	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	No	10008204-a6ghPlBFEOMDKBwRqoO0Q	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	10003752-7mwxLqXlG0il6qqyKSizYg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+76	Yes	10000364-1320904	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+50	No	419639-003972	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	No	10003752-LdpUysCCBEiq1sc8eKQPpA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+80	Yes	419639-009439	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	Yes	10000364-1706515	Not Reported	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	10008204-OawS4p8AKE6zagRPNFZWxg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	Yes	514382-007192	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+50	No	514382-034763	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	Yes	10003752-LduX0IIpJUCE3TGpnd0rEQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+77	No	419639-001608	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+69	Yes	10022779-P68UbhPoDUmJI6fr8pKqbw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+86	No	514382-040189	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+69	Yes	10000364-2450363	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+82	Yes	514382-010932	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+50	Yes	10003752-v9ffzK4Xk2PAGsqvfRhA	Not Hispanic or Latino	White	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+63	Yes	514382-000617	Not Hispanic or Latino	Black or African American	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+58	Yes	10022779-pg1qNA1hX0iJQnltfMeWBw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+81	No	10003752-cPpEdKTeHEOn1mfpIdT0Bg	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+78	No	514382-038659	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+80	No	419639-004426	Not Hispanic or Latino	Asian	Male	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+66	Yes	514382-006287	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+73	No	419639-008974	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+87	No	514382-015553	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+36	No	419639-004724	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+75	No	514382-040774	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+90	Yes	419639-004415	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+32	No	419639-006151	Not Hispanic or Latino	Black or African American	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+36	No	10008204-ozQegNsyF0yI8M02oeKDYQ	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+66	Yes	514382-000946	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	10000364-6553682	Hispanic or Latino	Not Reported	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+82	Yes	10000364-5437706	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+73	No	10008204-hnuItpna1EmAmdr1r1xvvw	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+41	No	10003752-ulxTVX96dUyeRZAZABQpWA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+58	Yes	514382-009871	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+29	No	419639-010252	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	Yes	10022779-i64Sad19lUymRGfzTlOg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+26	Yes	419639-004167	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+87	Yes	10000364-6435777	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	10000364-1103175	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+81	No	419639-008028	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+54	Yes	10022779-ODuYiIdseks3zaCStN6Ow	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+43	Yes	514382-007903	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	No	514382-036642	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+34	No	10022779-kMVrBKFsxUGyjKsycQE4IA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+24	No	419639-001552	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	Yes	514382-003704	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	514382-000170	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	Yes	514382-009411	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	10000364-1839931	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	514382-002197	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+43	Yes	10022779-MvBqcM9WWEaJJC0slcSew	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+50	No	419639-003741	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+890	Yes	514382-007559	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+35	Yes	419639-006921	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	No	419639-001400	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	10000364-1802350	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+29	No	419639-009221	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+82	No	514382-017307	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+59	No	514382-016154	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	No	514382-040413	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+30	No	10008204-RzpM4GqJSEBNOHxGKRMVg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	Yes	514382-009828	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+47	Yes	10003752-9nK6TCaI5Ee5jNqqVUcILg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	514382-005522	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+27	Yes	419639-005871	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+20	Yes	10022779-oVPxHULmEaebLk5pf1yQg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	10022779-BKpvdHkrUi00MdgUv1zw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+88	Yes	10000364-1413071	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+75	Yes	10000364-742055	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+54	No	10008204-0UKDADN9KUqcMFNpoyOdcQ	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+59	Yes	10003752-lPqzzmdCdEC6TG54jufCnw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+44	No	514382-037632	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+85	Yes	514382-004796	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	10000364-1598936	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+46	No	419639-003156	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+54	Yes	10000364-5900977	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+80	No	514382-015174	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+84	No	10008204-oIrfX55BXUGgSL2237Fgpw	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+85	No	514382-037371	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+57	No	514382-037752	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	No	419639-008966	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	10000364-1726149	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+39	Yes	419639-007649	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+74	No	10000364-2425082	Not Hispanic or Latino	White	Male	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+39	Yes	10008204-Gk0bpLMR10O6S1Y6Wln8fg	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+33	No	419639-008446	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+73	Yes	514382-006527	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+33	Yes	514382-005496	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+69	No	10008204-3OkdbdfceUaZ3ZoGlEA0w	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	514382-003022	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	10022779-fXDpSmtQsEeSDKQCMmloWQ	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	10022779-WHICiHgXgkSHTjQMPThxjg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+51	Yes	514382-000348	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+90	No	10000364-1575753	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+72	No	419639-004972	Not Hispanic or Latino	Asian	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+62	No	419639-003129	Not Hispanic or Latino	Black or African American	Female	"CT, DX"	FALSE	TRUE	TRUE	FALSE
+53	Yes	514382-013041	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	514382-007051	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+18	No	419639-005365	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+78	No	514382-017028	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+74	Yes	514382-006120	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+64	Yes	10000364-5559377	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+33	No	514382-038770	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+51	Yes	10022779-UcBoZLBzE6ILMSUj76JKA	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	10000364-1303126	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+60	No	514382-015015	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+50	Yes	10003752-xwv7m6rqkG6Hn0euEzUw	Not Hispanic or Latino	Black or African American	Female	"CR, CT"	TRUE	TRUE	FALSE	FALSE
+60	No	514382-040490	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+45	Yes	514382-007418	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+83	Yes	10000364-968592	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+77	Yes	10003752-wFnObYM4O0CD7gp30mPp3A	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+20	No	10008204-5q1mgpYpt0Ol3v8ldf8jOg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+46	Yes	514382-005763	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+85	No	419639-000329	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	514382-006456	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+40	Yes	514382-011690	Hispanic or Latino	Other	Male	CR	TRUE	FALSE	FALSE	FALSE
+57	No	10008204-wbELRPnmKEK0zOPZk1vg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+87	Yes	10000364-1933327	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	No	419639-005064	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	514382-006851	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	10003752-pAaAqkTFiE2mHaUUuXm8uQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+71	No	514382-038712	Not Hispanic or Latino	White	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+74	No	419639-006800	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+26	Yes	419639-010271	Not Hispanic or Latino	Not Reported	Female	"CR, DX"	TRUE	FALSE	TRUE	FALSE
+83	No	514382-034716	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+37	Yes	10022779-8reMLWN6ECHcvxatsWBpQ	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+57	Yes	514382-008077	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	Yes	514382-011414	Hispanic or Latino	Other	Female	CR	TRUE	FALSE	FALSE	FALSE
+35	Yes	514382-000283	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	419639-009717	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+50	No	419639-006254	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+24	No	514382-040943	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+48	No	10000364-1270298	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	10022779-jPmoFXuG70OcUUXlzg7bxg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+19	Yes	419639-010791	Not Hispanic or Latino	Not Reported	Female	"DX, CR, CT"	TRUE	TRUE	TRUE	FALSE
+58	Yes	10008204-JFVCCzT9tUeonCTeiiNaqQ	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	Yes	514382-006493	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+41	Yes	514382-004745	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+83	Yes	514382-001144	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+43	No	419639-010764	Not Hispanic or Latino	Not Reported	Female	"CT, DX"	FALSE	TRUE	TRUE	FALSE
+33	Yes	514382-006732	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	10022779-4MexOdJTUuXIitpXi3GXQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+73	Yes	514382-003212	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	514382-010286	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+71	No	514382-039626	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+37	Yes	514382-006442	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+50	Yes	514382-008138	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	514382-000763	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+40	No	514382-014600	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	514382-001279	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+84	Yes	514382-000355	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+90	No	419639-008156	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	No	10008204-TEBqIXR7XkK96fOU8AzQ0g	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+78	No	10008204-7516T0gz7UOvylyW1orODg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	10022779-w6OhBI4CE0CJ07FcN6INQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+46	No	514382-035672	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	No	419639-000587	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	514382-009046	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+64	No	514382-033955	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	10000364-5344152	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+26	No	514382-038541	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+48	No	514382-039194	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+90	No	10008204-Ip4fcW52EWlLfjpYKHelg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+29	Yes	419639-004356	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+33	No	10022779-neutu6P6nEhPwvi4ziRBw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+63	No	514382-034012	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+69	Yes	10022779-iHQ8npAex0moKbdkMyclw	Not Hispanic or Latino	Black or African American	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+890	No	514382-040234	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+66	Yes	514382-009392	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+54	Yes	10003752-JAtkcSczhECkwIeFkMkUA	Not Hispanic or Latino	Black or African American	Female	"CT, CR"	TRUE	TRUE	FALSE	FALSE
+77	Yes	10000364-6452978	Not Hispanic or Latino	Black or African American	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+77	No	419639-006873	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+25	No	514382-034112	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	No	419639-007301	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+38	No	514382-034379	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+73	No	419639-006090	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+56	No	419639-006377	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+49	No	10008204-joR0mweKFEKalJKqxo1nwQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+55	Yes	10000364-1579464	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+26	No	10008204-C9mGBYU0GkyQqO4Z1oei9Q	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+57	Yes	10000364-5820765	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+46	Yes	10022779-tcWJ2QQxr0a3gYcnE5uvAw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+40	Yes	10000364-6460911	Not Hispanic or Latino	White	Male	"DX, CT"	FALSE	TRUE	TRUE	FALSE
+57	No	419639-000395	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+890	Yes	514382-006044	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+45	No	514382-035715	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+84	No	10008204-5Ro5sYkprk2SzG3NUiI4GQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+36	Yes	514382-009058	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+71	No	514382-034336	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	10003752-cnHdEd8P0q4izIyNV9sZA	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+43	Yes	514382-009495	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+73	No	514382-017807	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+77	Yes	10008204-3jmWpH9GkuetbfEyrFqGA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+83	No	514382-037729	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	No	419639-011667	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+37	No	514382-016705	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+31	No	514382-035402	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+88	Yes	514382-006023	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+53	Yes	10000364-6516913	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+26	No	10008204-5GIWJ6IaJEa9e8KlpFzZiQ	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+64	No	10003752-uhiTJMXnwUV0wTu65VkoA	Not Hispanic or Latino	Black or African American	Female	"CR, CT"	TRUE	TRUE	FALSE	FALSE
+48	No	419639-009218	Not Hispanic or Latino	Black or African American	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+66	No	419639-008629	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	No	419639-009276	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+48	Yes	419639-007690	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	No	10003752-PxmSszRG0aG85FB5NRkaA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+35	Yes	10022779-ezxtswDGE2bSCNh63hA	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+50	No	10008204-cMTCUp4bYk2bh065e4a77w	Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	10000364-831472	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+38	No	419639-002307	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	10000364-6557899	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+19	Yes	10022779-ktysRt07jUKiXLXzg7MpiQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+76	No	419639-005281	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	No	10008204-m9GFujTuLUaOhvvZo2bfgw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+84	Yes	10000364-957258	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+47	Yes	10022779-m1b9BA5JUqbQ9779G72rg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+52	Yes	10000364-5794372	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+62	No	419639-010401	Not Hispanic or Latino	Not Reported	Male	"CR, CT"	TRUE	TRUE	FALSE	FALSE
+81	Yes	10022779-qfWiWLBCEqGqyjfJ5D2Bg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+40	No	514382-041523	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+69	No	514382-018204	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	No	419639-002557	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	No	419639-009597	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+39	Yes	10022779-qXMAq3NyU6JpBjy11asfA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+47	No	10000364-1111239	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+64	No	10022779-cNUYhaWEu02ASJ3e4H8ESw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-040918	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+43	Yes	514382-007469	Not Reported	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	No	10003752-7Tfsc47A0eGjHqz63BIRw	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+79	No	10008204-u7zG7G8RJ0qbXhwhJrTQ	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	No	419639-011424	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+67	Yes	10003752-WQfI63GFlURlL6ZeUlTLg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+74	No	419639-005811	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+50	No	514382-039794	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+45	Yes	419639-010995	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	10022779-XuUcaLoDs0WGbqhJZIb2ZA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+90	No	10008204-2Hs71amsYEuWowO5WyVf5A	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+42	No	10000364-5825177	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	10008204-qDlWjjRakGmG9yvysSSVg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	No	419639-000045	Hispanic or Latino	Not Reported	Male	"DX, CT"	FALSE	TRUE	TRUE	FALSE
+89	No	514382-017345	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+54	Yes	10008204-IwQqFF0506Zl5XvnxJhzg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+54	Yes	514382-008587	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+45	No	10022779-0BpB9rNJxEaEYYLqexhfGw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+78	No	10008204-AxwsAuxQjkWVqoZfnwNFxA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	10022779-tYBNUhdDsEaFZahrpxFxQ	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+80	No	10008204-g7vfbMk3vUCV5iMEMiJsJQ	Not Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+76	Yes	10000364-869635	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+78	No	514382-038053	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+890	No	514382-038960	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+69	No	419639-006849	Not Hispanic or Latino	Black or African American	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+68	Yes	10000364-5821128	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+45	Yes	10000364-1501159	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+69	Yes	10003752-Fy9zcaXHE4YSwUzR3Dhw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+80	Yes	419639-012595	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	No	10000364-1512667	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+26	No	514382-037955	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+88	Yes	514382-013084	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+64	No	419639-002543	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+79	No	419639-000391	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+43	Yes	10022779-I0nSJlawt0aMWiNn0OoZfA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+73	Yes	10022779-QlYxiQieEyNrVjjfZm5w	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+20	No	10008204-dL8ckCiDgU2uVyA8K4ZWxg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+38	Yes	514382-001905	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+71	No	419639-001133	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+50	Yes	419639-010162	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	514382-008341	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	10022779-nGCWrwXjQ0ysDbjIwxPFRA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+45	Yes	10000364-5402353	Hispanic or Latino	Not Reported	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+69	Yes	514382-007057	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+51	Yes	10000364-1581185	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+30	No	514382-036283	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+76	Yes	10022779-iKPmAFpvWUOMoCLHBxYnA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+60	Yes	514382-009351	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	Yes	419639-010499	Not Hispanic or Latino	Asian	Male	"CT, DX"	FALSE	TRUE	TRUE	FALSE
+22	No	419639-005116	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+68	No	514382-038518	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+77	Yes	514382-009302	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+69	No	10000364-5269900	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	10022779-Meq3EZyayEy33rYZ8cqsuw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+50	No	10000364-902020	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+69	Yes	10000364-5512407	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+78	No	10008204-Cm2kKDdhki76lngBwajUQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+72	No	514382-036994	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	No	419639-000868	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+68	Yes	514382-003882	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+77	Yes	514382-007096	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+49	No	10000364-848615	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+87	Yes	514382-005139	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+57	Yes	514382-006195	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+79	Yes	10000364-1360468	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-016808	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	No	514382-035312	Hispanic or Latino	Other	Female	CT	FALSE	TRUE	FALSE	FALSE
+67	No	10000364-5945377	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+37	No	419639-010337	Not Hispanic or Latino	Other	Female	"CT, DX, RF"	FALSE	TRUE	TRUE	FALSE
+60	No	514382-038066	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+32	Yes	514382-011095	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	No	10008204-VAMUUrGaLkqnwta3JszjIA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+54	No	10008204-F4d0gOqZLECFEVUJk8yY5A	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	No	10008204-TwQFFUh23E2JP2pkI81tPQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+25	No	419639-000120	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+78	No	514382-016184	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	10022779-qi9N1i1X6UuktcUzsQiNw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+82	Yes	514382-000157	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	514382-003203	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	No	10008204-IaErBer5dUWGTVy7E2LtQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+69	No	514382-037245	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	419639-007163	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+25	No	514382-034488	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+86	Yes	10000364-5643320	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+52	No	419639-011178	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	No	514382-039788	Not Reported	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+50	Yes	10022779-Zc8IW9b00mFRkRYLhVjjA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+23	No	10008204-LoKgcODEd0eUQ3K3lvizlA	Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+80	No	514382-035182	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+85	Yes	514382-011091	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	No	419639-002249	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+41	No	514382-037989	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+9	No	10000364-2731620	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	514382-005196	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	Yes	514382-013593	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+58	Yes	514382-009538	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+64	Yes	10000364-6076724	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	No	10003752-lreXb4jgiUGFWoE66v6gA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	419639-006805	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+51	Yes	10022779-VGDlH3HMZ0cOAIzTKgY5A	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+46	Yes	514382-008384	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+88	No	10008204-uIMGMdn7D0aXNikfEabV0w	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+87	Yes	10000364-94408	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+47	Yes	10000364-5514851	Not Hispanic or Latino	Black or African American	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+45	No	419639-001983	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+26	No	10000364-1732096	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+51	Yes	10022779-fIkaDwQRMkenu4B7xD4qTg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	No	419639-010171	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	10022779-MQ2oTEBmHku475DRygBB4Q	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+78	No	10008204-HIWGrBknw0ekm4xy2zWhPQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+75	No	419639-003806	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+74	Yes	419639-007895	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+76	Yes	514382-007687	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+90	No	419639-011257	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	10000364-1748630	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+87	Yes	10000364-848403	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+49	No	419639-011650	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	No	10008204-VAEsoBuFB0eFSphB6d5hQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+38	Yes	10000364-1515505	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+32	Yes	514382-009245	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+26	No	514382-035008	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	No	514382-035081	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+890	Yes	514382-004834	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+87	No	10008204-RY8onKtTtUK03D2dyfgSg	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+63	No	10008204-YyVaX4fdUepcOVGd32y9Q	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+33	Yes	10022779-NasQv8mFbEKwoa3LFfEDXw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+84	Yes	514382-000735	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	10000364-179385	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+36	Yes	10022779-cfwd0OD2hUQa0YR4lo0XA	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+26	Yes	10022779-MBQ1EOm770KOIMbResXYew	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+80	No	10000364-5409463	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+68	Yes	10022779-8pOasKVQUSxQQzabD2Xpg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+22	No	419639-001024	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+32	Yes	419639-010680	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+1	No	10000364-6600113	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+41	Yes	10022779-NEcKtSICki3lIU0vFBnyw	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	No	514382-038009	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+71	Yes	10003752-V4tyQAtEkuk1RPGUt0pvw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	No	419639-007374	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	514382-007976	Not Hispanic or Latino	Black or African American	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+40	Yes	514382-005787	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+60	Yes	514382-014044	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	No	514382-017964	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+52	No	419639-001303	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+28	Yes	514382-003720	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+90	Yes	419639-012286	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	No	419639-009934	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+28	No	10022779-oirNnL2bsE2BEDEHTbls2Q	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+57	No	10008204-KqRsg6PpnkuFQPKs0cptvw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	Yes	10003752-zucXGLeJ1kWOAQxswmwRpQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	10000364-1470727	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+73	No	514382-040204	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	Yes	10022779-qZn5Tg3h80OHEmd3DvApRA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+42	Yes	514382-005454	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+54	No	419639-001778	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	514382-011980	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+61	No	419639-002805	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-038498	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	No	514382-037369	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+26	No	419639-002179	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+79	No	10003752-R90Spa30E8Wzwwh5fQg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+28	No	419639-010274	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+79	No	514382-040657	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	No	514382-036533	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+28	Yes	10022779-DV7ORoR4EeqdbQGlTU1Kw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+25	Yes	514382-001903	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+72	No	514382-035903	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	No	514382-015121	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+39	Yes	514382-007256	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	No	419639-008615	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+62	No	514382-036402	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+69	No	514382-035637	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+53	Yes	10000364-2468504	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+27	No	10008204-RtV4z7Nw1EqWYvmaENsfZw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+66	No	419639-011802	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+26	Yes	10022779-jGzv0AjF0yq4phfOcjdnA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	Yes	419639-006299	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+25	Yes	514382-005492	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	514382-015457	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	514382-013589	Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+51	No	10008204-rQkSWUOovk67fx0avDmxAg	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	No	10008204-KsDAYyaUitY4HHoy58Q	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+80	No	514382-035320	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	10008204-U9xqLWM7v0ecfkWKoIrTyQ	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+24	Yes	10000364-8424	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	No	514382-040831	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	514382-002407	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+85	No	419639-004474	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	No	10022779-Y8ADl11okCarX6Z72P4Cw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+31	Yes	10000364-5201967	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+49	No	10008204-aR0rlfKUq0KBM7Dz4AMJyA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+61	No	10022779-fuARr3zYW0Gd0xc7EOonRw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+59	No	10008204-q5fel713SEqbXdIDG9Of6Q	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+35	No	514382-034200	Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+22	No	514382-034229	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+19	Yes	10000364-1036652	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+86	Yes	514382-006623	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	514382-000050	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	10000364-4963039	Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+0	No	10003752-aSnwUCtY4Ei8ZsAoBnsAnw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+58	Yes	10003752-Kw12sQPLkdsgzAmwDUHA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+47	Yes	10003752-MX0bIYyvTEyWTVe7idoNBw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+35	No	514382-035786	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+43	No	419639-000042	Not Hispanic or Latino	Asian	Male	"CT, DX"	FALSE	TRUE	TRUE	FALSE
+30	No	10022779-RLNclIii064nhoOBNtng	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	No	419639-011668	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+77	Yes	514382-006421	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	419639-002895	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+43	Yes	10022779-RhHwW75VzUOcSPoR5oRL9w	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+74	No	419639-006955	Not Hispanic or Latino	White	Male	"DX, CT"	FALSE	TRUE	TRUE	FALSE
+86	No	514382-017537	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	No	514382-038872	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+46	No	514382-041541	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+68	No	514382-036234	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+42	No	419639-004932	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+81	No	514382-038130	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+41	No	419639-010586	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	10022779-Ss8SkAoO8UKZMfteHSP4NA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+46	No	10000364-1397963	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	No	10022779-8Q55GQlb20y5TmqBs5aXcA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+48	Yes	10003752-T48imDtUrkSElSLe0NrHg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+46	No	10022779-AOb9S39VmUuoqa3CYk8G8g	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+90	No	10008204-5detHvW8HkK8r0AzJXuQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+57	Yes	10022779-VL5Js3xPTkWMlmNoWdHcQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+56	No	419639-003836	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+45	Yes	514382-010671	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+890	No	10008204-nf7RT0FaFEGlnGfPTaaWBQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-015958	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+62	No	419639-002080	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+71	No	10008204-ZlDvp6phcUyhAu8TRyMmsg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	No	10022779-NwzGYSDMUSQF6avJTgGBg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+68	No	514382-034966	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	No	514382-035076	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+49	No	514382-037783	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+25	No	514382-040828	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+59	No	10000364-1051786	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+68	No	514382-018200	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	514382-006703	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+48	Yes	10022779-zWgZeFHTk6pZVdVP63QWA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	10022779-GCehi772ZEimB1ZDROUg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	514382-007526	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+34	No	514382-037198	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+65	No	10000364-241893	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+35	Yes	514382-012009	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+85	Yes	10008204-3K0JFgFKmk2vwyw29MZwA	Not Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+60	Yes	10022779-SDWBj70ySUWV7biIRN5NZg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+29	No	10000364-1510367	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+50	No	419639-004175	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+29	Yes	514382-001665	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+21	No	419639-007719	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+82	Yes	514382-008001	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	10003752-sVV4GOz5nUanLC9B7Nc4Qw	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+48	Yes	514382-008882	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+68	No	514382-039269	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+61	Yes	514382-005302	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+77	Yes	10022779-ZnToCD5Hakah716ytZcWrw	Not Reported	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	No	419639-008056	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+64	No	10000364-5594966	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+59	No	10022779-Zxt1znnc1U617sF68WKbdA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+59	No	10008204-5DtWvErpEeFw4aDpBJYQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+67	No	514382-041177	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+82	No	10008204-kYLsWpbeU2DzX2AS25ncQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+74	No	419639-011374	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+50	Yes	10008204-OtS7RQEUPkOtrjMKC4gqA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+77	Yes	10003752-MnLtSMMYU0WsjQK9BbHfDA	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+52	Yes	10000364-5229185	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+77	Yes	514382-011353	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+77	No	419639-000243	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	514382-008304	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	10003752-pDx8zvn1kCAgGnrlS5foA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	10000364-2075415	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+41	No	10008204-rwfLJVgjckygDVfvL3uw	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	Yes	514382-010482	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+37	Yes	514382-003800	Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+46	No	514382-015218	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+21	Yes	10003752-AUXQvBwKxkW8nLysW7U69A	Not Hispanic or Latino	Black or African American	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+68	Yes	514382-006153	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	514382-006266	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	514382-001430	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	514382-007586	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+23	Yes	419639-011911	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+20	No	514382-034129	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+35	Yes	514382-012152	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	514382-034356	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+72	Yes	10003752-kuS85OcUSkCdVm8Ic4NAg	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	No	419639-000233	Not Hispanic or Latino	White	Male	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+60	No	419639-008884	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+41	No	419639-006093	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+73	No	10008204-RwZWZ9UyQUCXyFiD2dUQDQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	Yes	514382-008456	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	No	10008204-Kq4Msk5XEa5jWyl5GxHA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+78	Yes	514382-008959	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+75	Yes	514382-007811	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+32	Yes	419639-008554	Not Hispanic or Latino	Asian	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+63	No	10022779-6X5UXndb7EeF6yiyZ6yB0Q	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+44	Yes	514382-008899	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	No	419639-009751	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+79	No	514382-015991	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+23	Yes	514382-009771	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+90	No	419639-008703	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+999	Not Reported	10000364-16017697	Not Reported	Not Reported	Not Reported	['DX']	FALSE	FALSE	TRUE	FALSE
+19	Yes	514382-013426	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+80	No	514382-041077	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+26	Yes	10000364-1944429	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+39	No	514382-014974	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+48	Yes	10000364-1504191	Hispanic or Latino	Not Reported	Female	CT	FALSE	TRUE	FALSE	FALSE
+42	Yes	10022779-lX0ASiQi8kCHzU1JjPFltg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+74	Yes	514382-012583	Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	10000364-1782813	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+72	Yes	514382-008353	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	No	10008204-gBSzPNMhVEaZCBNJuo9dg	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+39	No	10008204-yXzty339ESOrCKgERyA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+83	No	419639-001740	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+57	No	10008204-JEvHkzcjrU2104CjjliBmQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+47	No	10008204-EEXEOmmBxECgNMi74SAEGw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+78	No	514382-039600	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	No	10008204-HzvrVJhsEOYztx4RdNccA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+30	Yes	10022779-l1w7EWRzFUWoBibSinlrJA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+34	No	514382-039327	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+75	No	10008204-41wKa2NC3U6HqKPyrrkNtQ	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+19	Yes	514382-007909	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+73	No	10008204-QL5mb5Oy0i7tjOGwLbBFw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+71	No	514382-039853	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	No	10008204-Fco8dMFY80C45u5XB4ibAA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+90	No	419639-007217	Not Hispanic or Latino	Asian	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+60	Yes	419639-009827	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+27	Yes	10003752-RG5NTtJiBEWgANvjl6p4vA	Not Hispanic or Latino	Black or African American	Male	"CR, CT"	TRUE	TRUE	FALSE	FALSE
+79	Yes	514382-008238	Not Reported	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	No	10003752-ERHNqZyAL0OSHtrQJ0mWA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+62	Yes	10000364-1601347	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+60	No	514382-017894	Not Hispanic or Latino	Black or African American	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+73	No	10008204-5cP3D6CUq8yfasqZ1l4A	Not Hispanic or Latino	White	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+63	No	10000364-449820	Not Hispanic or Latino	White	Male	"CR, DX"	TRUE	FALSE	TRUE	FALSE
+44	Yes	10022779-mEgpJ498r0uf57dLXdANPQ	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	Yes	10000364-2462749	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+69	Yes	10000364-1338822	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	Yes	10000364-5704268	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+70	No	419639-010346	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+51	No	419639-004740	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	10000364-1395705	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	514382-016617	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	No	10008204-bVn0J53PeEuwUOZoaM5jSA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+38	Yes	514382-010558	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	10022779-bEp8N44kWkmsu5KqJCJIcQ	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	Yes	10003752-NY3mgJsbOEiyNPyBaUBOEw	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+71	Yes	10003752-1VqzeuBkGE6XndOoSdXVvQ	Not Hispanic or Latino	Black or African American	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+5	No	10000364-4965497	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	No	10000364-1594259	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+83	Yes	514382-000799	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+50	Yes	10003752-lciZwujtEkaeV65X9BML8Q	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+82	No	419639-003637	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+59	No	10008204-1pedfEE9UUuHqAKJd4SQMw	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+56	Yes	514382-011571	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+40	Yes	514382-008888	Hispanic or Latino	Other	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+66	Yes	514382-010291	Not Hispanic or Latino	White	Male	"CR,CT,DX"	TRUE	TRUE	TRUE	FALSE
+67	No	514382-017992	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	10000364-590095	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+59	No	10003752-Wra6JQyQz0yw7m4TftVC4Q	Not Hispanic or Latino	Black or African American	Female	"CR, CT"	TRUE	TRUE	FALSE	FALSE
+63	Yes	10022779-WDVU0lUl7UqT0qPgHP1VrQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+55	No	514382-034174	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+25	No	514382-034642	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+80	Yes	514382-012588	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	No	10000364-1714062	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+85	Yes	514382-001484	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	514382-007236	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+33	Yes	514382-008893	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+73	Yes	10000364-1428470	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+72	No	514382-038055	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+90	No	10000364-1551201	Not Hispanic or Latino	White	Male	"CR, DX"	TRUE	FALSE	TRUE	FALSE
+59	No	419639-001772	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+71	Yes	514382-007753	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+47	Yes	514382-008943	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+88	Yes	10003752-wq6RodrTvUO6TXeEaBM8tA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	No	10000364-1422833	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+76	Yes	514382-000311	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+20	Yes	514382-005096	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+78	No	419639-009353	Not Hispanic or Latino	Not Reported	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+890	Yes	514382-003394	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	No	514382-040291	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+79	No	10008204-K8k9dwR4O0eORuyKK5m2Dw	Not Hispanic or Latino	White	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+41	Yes	514382-002560	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	Yes	514382-007754	Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+82	No	514382-036709	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	No	419639-012081	Not Hispanic or Latino	Not Reported	Male	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+67	Yes	514382-012500	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	10000364-82103	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+58	Yes	10022779-i1oprqdmFUm52qay54P01g	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+59	Yes	10008204-9x8kSAvAHkqacOw2tnL7w	Not Hispanic or Latino	Asian	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+62	No	10008204-VDmo0IPQpEKil20DiukbEQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+71	No	514382-017306	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+74	No	419639-002620	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	514382-002002	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+45	No	10000364-1624626	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+66	No	10003752-0VEFQfZAt0O8DexdZjDRA	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+85	Yes	514382-005330	Not Hispanic or Latino	Black or African American	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+35	Yes	10022779-8Fx6hoXl80qcp82nZ714kg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+60	Yes	514382-012566	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+74	No	514382-017802	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+75	No	419639-007534	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+45	No	419639-005685	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+69	Yes	514382-009869	Not Hispanic or Latino	Black or African American	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+50	No	419639-004881	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+33	No	514382-015016	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	10000364-6563400	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	Yes	514382-000212	Not Hispanic or Latino	Other	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	Yes	514382-011846	Not Hispanic or Latino	Black or African American	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+88	Yes	514382-011773	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	10022779-IlyTNToIoky6SUVARw4pig	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	No	419639-007973	Not Hispanic or Latino	White	Male	"CT, RF, DX"	FALSE	TRUE	TRUE	FALSE
+38	No	419639-002492	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+52	No	419639-008811	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+50	Yes	10000364-1748198	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+43	Yes	514382-012755	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+52	No	419639-006641	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	514382-007912	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	Yes	10008204-GH0EeVdqkWDoo7tpWJB1g	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+33	Yes	10022779-VEyB97OyEOcOIAGT39uEA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	No	419639-010177	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	10000364-1402040	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+69	Yes	514382-013620	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+75	No	10003752-nbeIExlk9EyLJgic6jqvAA	Not Hispanic or Latino	Black or African American	Female	"DX, CR, CT"	TRUE	TRUE	TRUE	FALSE
+33	No	514382-017158	Not Hispanic or Latino	Black or African American	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+73	Yes	514382-002313	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+890	Yes	10008204-tkgLqJcjRkyWHjLeKwKqlg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+73	No	419639-008214	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+43	Yes	10022779-63Zp2afpo0OsUee2ZH3yXA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	514382-004837	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+33	Yes	10022779-Nu9G5kows0GPFQ6Yqquy7w	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+48	No	10008204-jvugidxJ2k6IyAsTp4Rg0g	Not Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+63	Yes	419639-010962	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+43	Yes	514382-010954	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+67	No	419639-011713	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	No	10008204-HN8GKkQQ60O4PmpRBP06uQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+74	Yes	514382-007168	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+41	Yes	10022779-HqykZwcOyUeRWiUE075Tjw	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	Yes	514382-014208	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+3	No	10003752-BSt4oVBnkEyLBBPiQz1Zw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+44	Yes	514382-010843	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	No	419639-004059	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	514382-008014	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+30	Yes	10003752-WuS6pdXt602Wuhwl8yBeig	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	514382-011270	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+78	No	514382-014510	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+73	No	10000364-1330370	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+88	No	10008204-5IHSWAW0j0mpw5mlTf9UYw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+57	No	514382-034063	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	514382-008877	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+17	No	10000364-1273029	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+56	Yes	514382-007008	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	514382-005392	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	514382-008952	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+62	Yes	419639-001729	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+80	Yes	514382-009590	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+77	No	419639-012222	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+78	Yes	514382-008282	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	No	514382-016680	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+75	Yes	10000364-1516137	Not Hispanic or Latino	Black or African American	Male	CTPT	FALSE	TRUE	FALSE	FALSE
+64	No	514382-038295	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+73	No	10008204-Qf5zjQWNk6FZpk4NKuQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+32	No	514382-015211	Not Hispanic or Latino	Other	Female	CR	TRUE	FALSE	FALSE	FALSE
+61	No	419639-000755	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+20	Yes	514382-012197	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+50	Yes	10003752-qBQdPNHCE655UcBmZ0oSQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+36	No	514382-041160	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	514382-000456	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+81	No	514382-034020	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+22	Yes	10022779-LoQyN7ja0axBA356BnxGg	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+68	Yes	10022779-gC4WhBz0UGUFdG9RrNZCA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+17	Yes	514382-004893	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+40	No	419639-004237	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+41	Yes	10008204-td2TKTmIpUyp8YTg87z7gw	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+20	Yes	10000364-2596688	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+70	Yes	10003752-Y0pfCxgwvkCVorNsSDiJBQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+49	No	10008204-KQiczQmp0WwijwLbdY9Gw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+25	Yes	10008204-ue4XgfsZ6k6eaWz0WD5C3A	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+67	No	514382-035530	Not Hispanic or Latino	Black or African American	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+32	Yes	10022779-BulDQmoYU6y7Ao6sedjig	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+34	Yes	10022779-vH7NlY0m0aFww76StJy4A	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+51	No	419639-003011	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+30	No	514382-037100	Not Reported	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+19	No	514382-039559	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	No	10000364-5256724	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+35	No	10000364-5538686	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+37	Yes	10022779-KOPLBqH1UUuQ1fBltlhcCQ	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+38	No	514382-015956	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	10022779-4hwjkgOU0I9u8KunUUA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+79	No	10008204-rGliOYSjkGdbcW9s22Ow	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	Yes	514382-012119	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+31	Yes	419639-012288	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	No	10000364-234758	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+52	Yes	514382-005233	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+79	No	514382-041413	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+30	No	419639-001168	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+50	No	419639-003659	Not Hispanic or Latino	Native Hawaiian or other Pacific Islander	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+90	Yes	10003752-X2Ky7sjgrEaF3Q5OV1XBQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+62	Yes	514382-010719	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+59	No	10008204-Fj4JjmtxGUSwGqgLa7MBYg	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+41	No	514382-016105	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+40	Yes	10022779-jW1Z1nki0S5Z9qjLRFtKw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+26	Yes	10022779-OozcEXtSQUmjq7fGMBCfqA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+42	Yes	10022779-LhtY56xv60Ok3WJng8evw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+65	Yes	419639-007789	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+59	No	514382-035193	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+33	Yes	514382-006577	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	No	10008204-5RSgp1EduUe4z47S1qmiHQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+67	No	10008204-QjHhRbRLr0mcaiOrMO8VEA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	No	10008204-l14pXQ5cPESbjgJ2jsnFRg	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	10022779-pCF2Ba2i0UgXl4YTnt0TQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+66	No	10008204-ugmf1wVypkaAaHKZd27YXw	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	No	514382-017815	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+18	No	514382-017132	Not Hispanic or Latino	White	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+890	Yes	514382-001926	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+42	Yes	514382-012749	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+40	No	419639-009058	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+79	Yes	514382-000975	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	10003752-cViVukV9FEGzlTmAOFB3dQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+69	Yes	10022779-ofb2Lbqc70uU1SZ0YUkZwA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+54	No	514382-038809	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+33	No	10000364-6579452	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+75	No	419639-003742	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	No	514382-015098	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+86	No	514382-038103	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	514382-003779	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	419639-007030	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+81	No	419639-001107	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	Yes	514382-009025	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+31	Yes	10022779-6DVYicGzRU23bIRDjimGzA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+52	No	419639-010892	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+82	Yes	10022779-kOjkice2TEC5KZJzzRItsg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+20	No	514382-016695	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+83	Yes	10000364-1148709	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+56	Yes	10000364-6656811	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+26	No	419639-002767	Hispanic or Latino	Not Reported	Male	"CT, DX"	FALSE	TRUE	TRUE	FALSE
+45	No	419639-008781	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+72	No	419639-009580	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	No	514382-035121	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+20	Yes	10000364-6568581	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+66	No	10000364-940649	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+66	No	419639-000507	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+31	Yes	10022779-dus8EVkq9EC5Ado2l34liw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+25	Yes	10000364-148915	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+52	No	10000364-5728771	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+65	Yes	514382-011491	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	No	419639-011780	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	514382-002691	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	No	419639-002914	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+90	No	419639-006001	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+39	No	419639-004264	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+35	No	419639-011112	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+26	Yes	10000364-1184584	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+74	No	10008204-Akbkn1mll0arCYvzqvy0uA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+90	No	419639-011976	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	No	10008204-xc3vNVOIX0ZFojFQyezCg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+52	Yes	514382-006484	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+37	No	10000364-1559936	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+79	Yes	10000364-5744331	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+48	Yes	514382-003064	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+83	Yes	10000364-1490588	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+32	Yes	10003752-7qkGsWf5g0iPDN6ayKiag	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+61	No	10000364-2070132	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+72	No	514382-016698	Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	No	10008204-TuDdvvKkedrEw56w1mg	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+80	Yes	10008204-dedtTPckvkOkP7cmLpDy9g	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+68	No	514382-036801	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+42	No	10008204-RhWVGI6g70iwQX2A6gfiw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+40	Yes	514382-008403	Hispanic or Latino	Other	Male	CR	TRUE	FALSE	FALSE	FALSE
+53	No	10008204-atieGZONEWnw8opEk05Cw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	514382-004005	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	514382-009336	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+37	No	419639-002321	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+84	Yes	10022779-bWCFxhDKXk2I561GM6jYrA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+78	No	10000364-1835037	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+78	No	514382-041335	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+32	No	419639-008168	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	No	10008204-JQnWmYAZdEKF49Zj0Mo1LQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+66	No	10003752-k3FKoMnOZUaPnf43TrRZQ	Not Hispanic or Latino	Black or African American	Female	"CT, CR"	TRUE	TRUE	FALSE	FALSE
+51	No	10000364-1543043	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+64	Yes	514382-013548	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+55	No	419639-007701	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	10003752-cGHTPRVT8UScn4thSXhNBA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+890	Yes	514382-011442	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+41	Yes	514382-005718	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	Yes	10022779-wpTpm2kbNEKmNcSj2wXjQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+29	No	419639-000915	Not Hispanic or Latino	Asian	Male	CT	FALSE	TRUE	FALSE	FALSE
+77	No	10008204-W3gSLznv90CbxkzuUe62Yw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+68	No	514382-041216	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+27	No	10022779-pnuQIQJTsUWckMwltRzg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+41	No	419639-005194	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	514382-001675	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	No	419639-011043	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+33	No	514382-039812	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+76	No	10008204-1ygr3Q4JtEq1u7yOnz7xA	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+24	Yes	10022779-6rwI9aa8KEarl91MLfq2sA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+41	Yes	514382-007005	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+30	Yes	10003752-WGdD7JaEEWO2QE7O2Z3uw	Not Hispanic or Latino	Black or African American	Female	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+83	Yes	10000364-5712234	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+39	Yes	514382-013247	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	No	10000364-486376	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+33	Yes	10003752-HtSGClp9Y0C6XNccqcMJAw	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+65	Yes	10022779-EbSln10ob0W237vwR1XihQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+68	No	419639-012146	Not Hispanic or Latino	Not Reported	Male	MR	FALSE	FALSE	FALSE	TRUE
+18	No	10008204-tblSTu9bE2Fn5KKppQhbQ	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+59	No	514382-038626	Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+32	Yes	514382-007537	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	514382-004872	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+19	Yes	10022779-tdFzUHoC0y1JqAVou8Gw	Not Hispanic or Latino	Not Reported	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+75	No	514382-037154	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+25	No	10008204-JPj1ZyIr0mGt2zptoEHw	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+26	Yes	514382-006245	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+48	Yes	10022779-WguDH0mXESYtj4fPtVBcg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+90	Yes	419639-006772	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+50	No	419639-009269	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	No	419639-012059	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+48	Yes	10022779-oMoYZPpqy06suXWOuZx7w	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	No	514382-037184	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+67	Yes	10022779-4vb5nbOkgkWvlLnCDj1qKw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	514382-008151	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+55	Yes	10022779-u1hv10BXGEGI2PeHrZsSAw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+65	No	10000364-1483996	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+45	No	419639-006845	Not Hispanic or Latino	Other	Female	CR	TRUE	FALSE	FALSE	FALSE
+71	No	514382-040968	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	No	10000364-5969547	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+74	No	514382-015658	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+78	No	10008204-rExZYXOsXEOZy6eHVMhsyg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+74	No	514382-014682	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+41	No	10022779-e0mhUZbqU6rffoVsPiksA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+58	Yes	514382-009596	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+39	No	10000364-5949352	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+46	Yes	514382-005653	Not Reported	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	10000364-5441378	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+890	No	10008204-0fhQcYdjUGirqzKAZLbA	Not Hispanic or Latino	White	Male	"CT,CR,DX"	TRUE	TRUE	TRUE	FALSE
+80	No	10000364-1598653	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	10022779-EBrsakVfEqwq2tpkPTCrg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+47	No	10000364-1234521	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+71	No	419639-010573	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	No	419639-001229	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+39	Yes	10008204-ofkxzUGcsUOBTuKEEFaavQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+25	No	514382-038293	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+74	No	514382-015169	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+67	No	419639-003589	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+29	No	514382-014857	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+64	No	10008204-J4yfGGd8v0Wp6z06wceKhg	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+49	No	419639-000781	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+30	No	419639-000151	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+36	Yes	10022779-5NnIrGr3uk6M1K6lTx0hFw	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+38	No	10022779-NaXyrurViEy0rCF7lnRCvw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+67	No	10003752-GpDUbKW50C24eZsMBAxYQ	Not Reported	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+56	Yes	10022779-hGtWyRs1kKL8HRWVQtTWg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+52	No	419639-009532	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+25	Yes	419639-010929	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+77	No	10008204-Lg24XIemh02BJ1rMgBQNBQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+32	Yes	10000364-566526	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+40	Yes	10000364-1005385	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+22	No	514382-035887	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	No	419639-002213	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+45	Yes	419639-007688	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+52	No	10008204-uiGIt94FwEqvrMUdfkXhQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+32	No	10022779-UnLGj5QWiUy7Wl79mdgryw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	Yes	10003752-XwSaPGJ7Uub93MDRrQCOg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+42	Yes	10000364-6463679	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+30	Yes	10000364-1580900	Not Hispanic or Latino	Black or African American	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+34	Yes	514382-008806	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	Yes	514382-006744	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+83	No	514382-040371	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+38	No	514382-039283	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+26	No	419639-002415	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	514382-001010	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+35	No	514382-015821	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	514382-004080	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+77	No	514382-037298	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+85	Yes	514382-010889	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+53	No	10000364-5221034	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	No	514382-038867	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+30	No	419639-001738	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+62	No	419639-011920	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+65	Yes	10022779-HAnl9dQ6mECUjDOty4gzew	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	10000364-920844	Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+41	Yes	514382-007540	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+54	Yes	10000364-1485276	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+46	Yes	10000364-6206869	Not Hispanic or Latino	Black or African American	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+23	Yes	10000364-6560252	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+40	Yes	514382-003964	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	No	514382-015438	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+63	No	10000364-1655267	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	No	10000364-875301	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+82	No	419639-007328	Hispanic or Latino	Not Reported	Female	CT	FALSE	TRUE	FALSE	FALSE
+72	No	514382-034016	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+46	Yes	514382-006503	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+29	No	419639-010381	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+59	No	514382-035439	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+52	No	419639-001411	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+41	No	10003752-MOjgLE0SEabJfGVMzmjww	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+76	Yes	514382-001156	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+52	No	514382-037909	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+30	Yes	10022779-mcvINSXYnk6NAydXZ24EgA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	No	419639-008329	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+36	No	419639-009183	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	No	10000364-1386454	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+81	Yes	10000364-6112171	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	10008204-MUk7zOUkfEKROlptYgExWw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	No	10008204-Ge2uKfzIECooLDfxiwg1A	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+30	No	419639-010954	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+53	Yes	514382-011626	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	10008204-G6Ma82V1vUmsWZAG1OJ9qA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+54	Yes	514382-008932	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	10000364-837213	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+27	No	514382-015406	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	No	10003752-69exHnlaekKc10ipNWQ21Q	Not Hispanic or Latino	Black or African American	Male	"DX,CR,CT"	TRUE	TRUE	TRUE	FALSE
+31	Yes	514382-002817	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+90	No	419639-007854	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	419639-004661	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	No	514382-017975	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+84	No	10008204-LxGRml6IEWkXI0uCVGfbQ	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	10022779-KGfTX3VbYkeNx7bemmXvPg	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+84	Yes	10008204-1Ug8f5UkU0yOKJhGwJcqg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+3	No	10003752-qoRYEapyXEyGUxC511DQWQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+44	Yes	514382-010418	Not Hispanic or Latino	Asian	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+74	No	10008204-7dnh5rIgRUutqy4hU4gWiA	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+47	No	514382-017480	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	No	10008204-hn3p3OMSiEOsTCkHqaF9A	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+18	Yes	10000364-6431202	Not Hispanic or Latino	Asian	Male	CT	FALSE	TRUE	FALSE	FALSE
+57	No	419639-004902	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+81	Yes	514382-003645	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	514382-013122	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	514382-000048	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+64	No	419639-011090	Not Hispanic or Latino	Not Reported	Female	"DX, CT"	FALSE	TRUE	TRUE	FALSE
+57	No	419639-000084	Not Hispanic or Latino	Asian	Female	"CT, DX"	FALSE	TRUE	TRUE	FALSE
+25	Yes	419639-009914	Not Hispanic or Latino	Not Reported	Female	"DX, CT"	FALSE	TRUE	TRUE	FALSE
+28	Yes	10022779-8UulofgJ10SaneRYzVXURw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+43	Yes	10003752-jhSuelQlxkCyY7W1uuqkKQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+80	Yes	514382-012022	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+52	No	419639-011256	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+37	No	10022779-dJkEH7YoeUCtUGwsyOHQBA	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+36	Yes	419639-012622	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	514382-004107	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	No	419639-003581	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+17	Yes	10000364-1405094	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+86	Yes	514382-001283	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+37	No	419639-002788	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+41	Yes	10008204-gvpvjbTUNUqKUGq8tu1Dfw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+30	No	10008204-XOFNd7XFAEG4kLWHhKI8jg	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	514382-013192	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+40	Yes	514382-004040	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	No	419639-012148	Not Hispanic or Latino	Not Reported	Male	"DX,CT"	FALSE	TRUE	TRUE	FALSE
+72	No	10008204-VT1mH9DzC0yKjLsrxkA9w	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+35	No	419639-000240	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+86	No	10008204-legwZZ6ZzUKYziCxgRJrKg	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+57	No	10008204-yFcvzfOe7kCunudYPRW6bg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+35	Yes	10008204-QrKi7RRZkUuuF7Y0cw5sQA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	Yes	514382-012814	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	514382-004240	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	No	10003752-NvOGZVeiHkOpYaaNQ3aBRA	Not Hispanic or Latino	White	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+23	Yes	10000364-977123	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	No	419639-009272	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+80	No	10000364-1359844	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+89	No	514382-040054	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	514382-041207	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	No	10000364-1812278	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+52	No	419639-008390	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	Yes	10003752-KVM4sxQf1UKqLGzFm8RgBQ	Not Hispanic or Latino	Black or African American	Female	"CT, CR"	TRUE	TRUE	FALSE	FALSE
+46	Yes	514382-001369	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	No	10008204-Y4S4T33QIkaktHwppmgpeQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+32	No	514382-037924	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	419639-012260	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	514382-006297	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	10008204-Y54f1CabjEmd2OuXOiFwg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+56	Yes	514382-012291	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+30	Yes	10022779-sZ055BrFNUaklne68hvw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	No	10003752-g1bhbWYdVEirJt68UVcNw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+30	No	10003752-59gaW3Mxy0OLUdoW3luX9Q	Not Hispanic or Latino	White	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+46	No	514382-040910	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+3	No	10003752-JbbIMTY1FEOqJVvtako2aw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+55	Yes	514382-000547	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+51	No	514382-036741	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+79	No	10003752-03UJbtnPEazkWgdX5nug	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	No	419639-006006	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	514382-000541	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+30	Yes	514382-011921	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+90	No	10008204-tpBxrEvjm0iOOBIsuR1maQ	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+53	No	514382-016446	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+77	Yes	10003752-2oYh5A9dUWX90aAGYReMw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+79	No	419639-011176	Not Hispanic or Latino	White	Male	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+55	Yes	514382-005349	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	No	419639-009960	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	10022779-BS08anmZECaw9uXTutw1Q	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+72	No	10003752-c2EGd9iNFkWMRbOjiE7xcw	Not Hispanic or Latino	Black or African American	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+30	Yes	514382-003056	Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+68	Yes	10000364-150315	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+83	Yes	514382-008253	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+73	No	514382-015613	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	10000364-1368135	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+37	Yes	10008204-9uU46YVi0SHWa5fvzVSw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+33	Yes	514382-004179	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	No	10003752-A6WNGh82Y0KFmhHjHufQkg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+34	Yes	10000364-2697026	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+890	Yes	514382-010887	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+45	Yes	10022779-NhJ0ot4SLUWcHKzDD6AWTw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+48	No	10000364-1925141	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+23	Yes	514382-003273	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	No	514382-039563	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	10003752-xQas52XjkG8yWchENAB5Q	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+42	No	514382-040068	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+890	Yes	514382-004722	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	No	514382-041019	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+71	Yes	10008204-ND7ei7Z2EUVLYpQPxag	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+80	No	514382-016077	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	No	10008204-yn7Ipj2wZEe3jML3NnHg	Not Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+65	Yes	514382-006293	Not Reported	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+53	Yes	514382-011922	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	514382-007020	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+78	No	514382-018257	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	No	514382-036418	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+80	No	514382-014319	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+30	Yes	10022779-yUWGiTcKZ02fAorfKOGpvQ	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+45	Yes	10000364-1125559	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	No	10000364-473457	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	Yes	419639-012367	Not Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+890	No	514382-038067	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+48	No	419639-006897	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	419639-002423	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+81	Yes	514382-011433	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+45	Yes	10000364-5458065	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+45	Yes	10022779-kQnoEGUkEEyrIAtfEO0pAA	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+79	No	419639-006549	Not Hispanic or Latino	Black or African American	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+74	No	419639-003837	Hispanic or Latino	Not Reported	Male	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+86	No	514382-038889	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	514382-011532	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	Yes	514382-007677	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+83	Yes	10003752-7gFtp2Y40CUVI5ETRfZmg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+77	No	10008204-O3jlzK3I06vrQ0BnrisIw	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+86	No	10008204-KRRmWwr7X0y2WY2W2aUvA	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+85	Yes	514382-000323	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	No	514382-035487	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+43	No	419639-009643	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	514382-010302	Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+56	No	419639-008172	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	10003752-ouNvCpwXdkShW2ffHDi7Mg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+42	No	419639-003038	Not Hispanic or Latino	White	Male	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+30	No	514382-017800	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+43	Yes	514382-007232	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+61	Yes	10000364-2019317	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+57	No	419639-004883	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	No	10003752-egRoRdAtq0CPMHvdphrdJg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+66	No	514382-034179	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	514382-005518	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+45	Yes	514382-010752	Not Reported	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	No	10000364-727636	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	No	419639-010300	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+62	No	10022779-NcmWPl9TAk6PHO8Xt6dxCQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+69	No	419639-008387	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	10000364-1940843	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+32	Yes	10022779-1GcDBHGt1kiPcWAWrPYgHg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+65	No	514382-038569	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+890	No	10008204-bq69iVQQxkKbzIvpjawphg	Not Hispanic or Latino	White	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+45	Yes	514382-008308	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	Yes	10003752-dMN36DNlBEGJ0WZbEfZdGA	Not Hispanic or Latino	Black or African American	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+50	Yes	10000364-5527993	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+36	No	419639-002086	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	No	419639-001985	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	No	419639-009399	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+34	Yes	514382-003449	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+86	No	514382-035569	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+80	Yes	10003752-6FlKY0V20a1WOVwosq1A	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+52	No	419639-000625	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	10022779-551oyz6PWECeZXQ0xjxgyQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+58	Yes	10000364-1486487	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+56	Yes	10022779-qkEOp5yWkSQ4hFRxWUrVA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+27	Yes	10022779-RgmeN6TRoU6anbJvEmG1g	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+31	Yes	419639-009645	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+68	No	10000364-896108	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+58	Yes	514382-001776	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+17	No	10008204-jjnpxHnePkCUX3HeqpGQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+80	No	419639-012272	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+84	No	10003752-88PZTBELikamedjuQSRh4Q	Not Hispanic or Latino	Black or African American	Male	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+39	Yes	514382-008537	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+44	No	419639-000514	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	No	419639-008697	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	Yes	419639-012402	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	No	10008204-7dydMB2CUCGAYEllRFGKg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+19	No	514382-015996	Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	No	10000364-1125242	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+75	No	514382-039927	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+33	Yes	10000364-1119749	Not Hispanic or Latino	Black or African American	Female	MR	FALSE	FALSE	FALSE	TRUE
+74	Yes	10008204-91htEe7r0OUdWeNcPtIA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+65	No	10000364-1555251	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+66	Yes	10000364-5314199	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+57	No	514382-017165	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	Yes	10000364-1314092	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+38	No	419639-001546	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+45	Yes	10000364-1272493	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+79	No	514382-040064	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+20	No	10008204-j6jB4VhVREms8TRN96CQw	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+89	No	419639-010123	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	No	419639-012598	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+81	No	10008204-20slG0aE6AJt2ZCkO0zA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+38	Yes	514382-014087	Not Reported	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+77	No	10008204-6k7TrvZkUW3k5SjBBURPQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+67	No	10008204-UVfDaHkxF0uwKq99QBQK6Q	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	514382-006630	Not Hispanic or Latino	Black or African American	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+60	No	419639-006520	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+56	Yes	514382-001871	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+73	No	10008204-qjBpMs2pESGfyt9Af39pw	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+79	No	514382-040137	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+45	No	514382-035879	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+28	Yes	10008204-JTZt7wpHE0unnTxEgSMh3g	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	514382-012561	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+76	No	514382-017425	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+49	Yes	514382-004301	Not Reported	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	No	514382-036108	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+14	Yes	514382-013414	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+26	No	419639-010688	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+69	Yes	514382-005540	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	No	10008204-mxQLivckxEOFTlctYRNDw	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+79	No	10000364-706378	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+69	No	514382-040584	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+84	Yes	419639-006769	Hispanic or Latino	Not Reported	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+73	No	514382-039512	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	514382-000377	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+87	No	514382-016380	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+2	No	10000364-6188358	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+90	Yes	10008204-JfrkDgU9nUi3IpibglpXlQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+22	Yes	419639-010699	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	No	514382-034223	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	Yes	514382-002264	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+36	Yes	10022779-vq3krJkO40WZ6IuUO7m8w	Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+31	No	514382-014793	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+25	Yes	514382-012915	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	514382-001416	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+32	Yes	10008204-80rDE1ciRkq7LpgyMAyw	Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+46	No	514382-015783	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+67	No	514382-037417	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+21	Yes	10003752-4DyWfNyg006kq2ZDHT600Q	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+75	No	419639-001351	Not Hispanic or Latino	White	Male	RF	FALSE	FALSE	FALSE	FALSE
+24	Yes	514382-012219	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+39	Yes	514382-001951	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	No	10000364-1592685	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+68	No	514382-035830	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+65	Yes	514382-003922	Not Reported	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+45	Yes	10022779-StWucQWTU2yFxJ0sAfTw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+45	No	419639-009974	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	514382-005962	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+28	Yes	419639-010014	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+79	No	10008204-R5pK2tWZiEij1A4OtfLM1A	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+56	Yes	10022779-YrLqUaX96UiknmhY25GRKw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+75	Yes	514382-008452	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+30	Yes	10000364-1575459	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+56	Yes	514382-000305	Not Reported	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	10000364-5658746	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+31	No	514382-034720	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	10022779-yNoUAdxZV0unVfLi1JJmhw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+26	Yes	10003752-Npi2euUpEarTYgrnthQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+37	Yes	10022779-XGFkEWXD1UKH2B0mxgN3tA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+32	No	514382-036324	Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	514382-003806	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+80	Yes	514382-001407	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	514382-003317	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+64	Yes	10000364-1369536	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+34	Yes	10022779-kURhrlURJ0OAhLXQyq1vmg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+21	Yes	10022779-ul7htd7LVEGD2ealKWwxA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+40	Yes	10022779-tFaYMde0EuTzYOv3bQlBg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+52	No	10000364-1717993	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+24	Yes	514382-001858	Not Hispanic or Latino	Asian	Male	"CR,CT,DX"	TRUE	TRUE	TRUE	FALSE
+77	No	514382-035034	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+54	Yes	514382-002764	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	514382-006762	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	10022779-HfWJotMCYUCEDReZlkNYaQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+890	Yes	514382-001485	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	No	514382-038571	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+67	No	419639-000443	Not Hispanic or Latino	Asian	Male	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+36	No	419639-008936	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+75	Yes	514382-003188	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	Yes	10003752-G3j6mmr4UGRGwswAmFhA	Not Hispanic or Latino	White	Female	"CT, CR"	TRUE	TRUE	FALSE	FALSE
+59	Yes	10000364-6523898	Not Hispanic or Latino	White	Female	MR	FALSE	FALSE	FALSE	TRUE
+64	Yes	514382-008126	Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	419639-008848	Not Hispanic or Latino	Asian	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+67	Yes	514382-008521	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+40	No	514382-018211	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+24	No	514382-036400	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	No	514382-041453	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	10003752-gGkiqFg05EqTNdUTak4eww	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	No	514382-035087	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+78	Yes	10022779-T89J4r1YvUGrv1nhIzGpog	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+56	Yes	514382-005204	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	No	10008204-fMOtzhsp0GJahSpSxxXeQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+73	No	514382-034551	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+72	No	10008204-VMcSWkcewkCD4KjVhPzzvg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+54	No	10000364-1938585	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+75	Yes	10000364-5794383	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+36	No	514382-015653	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	10000364-1840321	Hispanic or Latino	Not Reported	Female	MG	FALSE	FALSE	FALSE	FALSE
+26	Yes	514382-003534	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+68	No	419639-000219	Not Hispanic or Latino	American Indian or Alaska Native	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	419639-004829	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+48	Yes	514382-010046	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	Yes	514382-009946	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+77	No	514382-039834	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	10022779-GlHwlnKusUeP3vD2rvHt9A	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+55	No	419639-011450	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+30	Yes	514382-012846	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	514382-007723	Not Reported	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+31	Yes	10022779-XN7UGCd8NkiJDX0dA3HWw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	Yes	514382-012446	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+41	Yes	10008204-4vV70BqrmEWHJnRRz0NsdQ	Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+28	No	10008204-nsvoZMiv0US298BY2vFKLQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+39	No	10022779-HITCKsklnkG7vcqbXIiCSw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+87	No	514382-038908	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	Yes	10022779-FwKbj5cIUujFQpmjmI3A	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	No	10008204-ae7LjAPCHUiRBYqv74vrew	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+62	No	10008204-RDaWe8NxUacDcQuD2P98Q	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+54	No	10008204-PJIzGlrQ8kyJEqIpyJOo4w	Not Hispanic or Latino	White	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+58	Yes	514382-003513	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+33	No	419639-003122	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	514382-007721	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+80	No	10008204-Gg3YjTBDSU6cU2zd8dMKw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	No	514382-037181	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	10000364-6525931	Not Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+890	Yes	514382-001504	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	No	10000364-421992	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+21	No	419639-005328	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	10022779-kkXvsFqXnUaPIDrF4hnoQ	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+79	No	419639-007254	Not Hispanic or Latino	Native Hawaiian or other Pacific Islander	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+64	No	514382-035365	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	No	10000364-2444720	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	No	514382-038684	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	10000364-2692216	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+49	Yes	514382-003322	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	No	419639-000279	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	10000364-6547573	Hispanic or Latino	Not Reported	Male	"CT, MR"	FALSE	TRUE	FALSE	TRUE
+90	No	419639-001978	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+50	Yes	514382-011327	Not Hispanic or Latino	Black or African American	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+34	No	514382-016047	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	514382-003214	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+34	Yes	10000364-1058314	Not Hispanic or Latino	Black or African American	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+70	Yes	514382-003625	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+82	No	419639-003393	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	10008204-fioT32IhZkS0bCcaHTdHIw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+67	No	10008204-0MN76Ngux0yn1iC8yOWPyw	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	No	419639-003326	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	No	514382-015550	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	10003752-sxI70RBdQ025KtsVUJe4lQ	Not Hispanic or Latino	White	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+31	Yes	10000364-5622641	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+35	No	419639-002915	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+86	No	514382-017685	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	10022779-sZw4YewPMEiEUPvGwncEuw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	10008204-XbkslHLd0WNNdI8FCXbg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	No	514382-018176	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+34	No	514382-036929	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	No	514382-015842	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	514382-006134	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	10022779-HS2BSai3UKxYr8nwTpdiQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+77	No	419639-011002	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+53	No	419639-011438	Not Hispanic or Latino	Not Reported	Female	CT	FALSE	TRUE	FALSE	FALSE
+69	No	514382-040875	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	10022779-q4SY6TGcTUiX8Mj8twdVhw	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+52	No	514382-041131	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+65	No	419639-012055	Not Hispanic or Latino	Not Reported	Female	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+88	No	10008204-Cxd7Oc79D0eWlFcxFLIzxQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+68	Yes	10022779-Wfh254H1NkSrsTqKUBaXfA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+43	No	514382-034100	Hispanic or Latino	Other	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	No	10008204-GeP8FmoJh0mkX6SZRAylg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+28	No	514382-036185	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+23	No	514382-040782	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+28	Yes	10022779-mIv04XQoCEiNRDNfP8uV9g	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+77	No	419639-003749	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	Yes	10000364-2329128	Hispanic or Latino	Not Reported	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+50	Yes	10008204-8GoUtVyU4kyKjLOOZGcahA	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+87	No	419639-009085	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+43	Yes	10000364-1719726	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+52	No	514382-015560	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	10022779-mD4TdiVyz0GozYI4REg5fw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+78	Yes	514382-013110	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+890	Yes	514382-002548	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	No	514382-017774	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+25	Yes	514382-010567	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	No	514382-035732	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+49	No	10000364-628025	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+78	No	514382-035104	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	No	514382-035450	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+44	No	10003752-ehamPN4XREaR1v0AwKvOA	Not Hispanic or Latino	Black or African American	Male	"CT,DX,CR"	TRUE	TRUE	TRUE	FALSE
+50	No	514382-016194	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+73	No	10008204-n9OvcNNEr0Or2akuCkMROA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	No	419639-005557	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+28	Yes	514382-003956	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+40	No	419639-002559	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+77	No	514382-016015	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	No	10008204-JpSNrrQl3EipKckUX3knOw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	No	514382-016625	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+78	No	514382-036356	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+81	No	419639-007662	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+74	No	10000364-1452855	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+29	No	10003752-Teo9pjzDVUg6htb7YbEoA	Not Hispanic or Latino	Black or African American	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+53	Yes	514382-011925	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+21	Yes	514382-010869	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	No	514382-016648	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+48	No	10022779-0o1X5ysE9U2g7xUDiEULww	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+55	No	10000364-1112913	Not Hispanic or Latino	American Indian or Alaska Native	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+58	Yes	10000364-1557150	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+63	Yes	10003752-WfQ8ctwF1kCy3BtnABkYQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+53	No	10008204-upTkCYjM9EMBwIgV57E5w	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+34	Yes	10000364-1578029	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+38	Yes	10022779-11v6CrGgj0CSRg8qNZQDyQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	10000364-1519736	Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+47	Yes	514382-004270	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+67	No	514382-016710	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	No	10000364-1319430	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+73	No	419639-001228	Not Hispanic or Latino	Asian	Male	CT	FALSE	TRUE	FALSE	FALSE
+73	No	514382-014350	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	No	514382-038250	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+72	No	419639-007451	Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+22	Yes	514382-003867	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+79	Yes	514382-012698	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+63	No	419639-006276	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	10000364-844904	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+81	No	10000364-1327260	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	No	10000364-1630808	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	10000364-1271314	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+29	Yes	514382-002933	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+21	Yes	514382-000759	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	No	10008204-R6dz1WFz9EaVLm4hlREWXg	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	10022779-thsfeWZU5EKzbY3WnXmHw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+63	No	514382-036301	Not Reported	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+83	Yes	514382-004844	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+35	Yes	514382-005644	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	419639-006906	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+40	No	514382-039226	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+38	No	514382-017085	Not Reported	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	Yes	514382-014003	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+46	Yes	514382-008431	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	No	419639-004358	Hispanic or Latino	Not Reported	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+29	Yes	514382-010585	Not Reported	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	No	514382-035346	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	10022779-Y0hZelcVdkWIkmCLMxaROg	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+63	No	419639-000922	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+61	No	514382-036661	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+50	No	10000364-1588348	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	No	419639-000174	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+54	No	514382-017514	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	514382-004021	Not Reported	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	419639-011056	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+36	Yes	10000364-2458190	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+37	Yes	514382-014268	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+79	Yes	514382-010824	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+77	No	514382-037052	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+52	Yes	514382-010311	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+25	Yes	514382-004351	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	10022779-3BQjUGgLLk6dSwmmvsZFw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+55	No	419639-010617	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+16	Yes	10000364-1372804	Not Hispanic or Latino	White	Male	MR	FALSE	FALSE	FALSE	TRUE
+63	No	419639-003138	Not Hispanic or Latino	White	Male	"CT, DX, CR"	TRUE	TRUE	TRUE	FALSE
+59	No	419639-011825	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+39	Yes	10008204-wRKW5Zuq6UeiIZAdV6fosQ	Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+57	Yes	514382-001040	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+68	No	419639-009152	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+37	Yes	10022779-a10a57Hey0ijbul7T6aA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+68	Yes	514382-002237	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+82	No	514382-040102	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+84	Yes	10003752-HSWr8823NUS9yyqv3psPA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+68	No	10008204-NQeSe4EJEm29vuHBItV5w	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+37	Yes	514382-013179	Hispanic or Latino	American Indian or Alaska Native	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	514382-001779	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	No	10008204-jziHNUfN0W7rxWMXfkYCg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+78	No	419639-001224	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	No	419639-002831	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	10000364-1909588	Not Hispanic or Latino	White	Female	MR	FALSE	FALSE	FALSE	TRUE
+87	Yes	514382-008099	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+33	Yes	419639-007236	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	No	514382-014840	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+88	No	514382-034848	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+51	Yes	10022779-FUGZdwZUT0ua9JRXpUBlg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+50	No	514382-039252	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	No	419639-007271	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+52	No	514382-038627	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	10000364-5472476	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+45	Yes	10000364-6276475	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+71	No	10008204-hoeyE0nvk2m2S6yyVcnbg	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	No	514382-038564	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	No	419639-002025	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+76	No	10000364-6392979	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+46	No	514382-036106	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+85	Yes	514382-012531	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+53	No	10008204-0OSaZd9OIESmEJSc90vg9Q	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+34	Yes	514382-003398	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	10022779-lEwOmUerbEadAWwvQZ9Juw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+36	Yes	514382-001335	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	10003752-qf5Jpc6Ukyki1gp31bWGQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+76	No	514382-033922	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	No	514382-037869	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+90	No	10008204-X71GAZ4vS0Gr08Bq50DaDg	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	No	419639-008023	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+19	Yes	10003752-2ye7UcDW0Kd7F4wtHDI1w	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	10022779-FaN2QvWrfk67ccSmTRNvg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	No	10008204-HZxohIEiqEGGSVkIQNIpw	Not Hispanic or Latino	White	Male	"CT,CR,DX"	TRUE	TRUE	TRUE	FALSE
+61	No	10008204-IBSN0X9bEEK5p0xdGDuvg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+80	No	10008204-b6kldF69QE2wzaMMAsqUeA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+890	Yes	514382-003066	Not Reported	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+78	No	514382-033909	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+50	No	419639-009635	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+79	No	514382-017234	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+63	No	419639-003177	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	10000364-6556264	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+78	No	514382-018189	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+62	No	10000364-5539091	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	No	10000364-1432584	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+890	Yes	10008204-xmio6vZMEkyIMrtLpohsgA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	514382-008337	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+76	No	10008204-Xhcjlb02UyeupSV8sGeig	Not Hispanic or Latino	White	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+57	No	419639-004971	Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+58	Yes	10022779-7bnMhjziEyh3QhbMGWYyg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+33	Yes	10000364-5756817	Not Hispanic or Latino	Black or African American	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+77	No	514382-040247	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+25	Yes	419639-009432	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	No	419639-000072	Hispanic or Latino	Not Reported	Female	"CR, CT, DX"	TRUE	TRUE	TRUE	FALSE
+46	No	514382-040199	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	514382-004798	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+77	No	419639-007991	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	514382-005220	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+79	Yes	10000364-991595	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+80	No	10008204-aSK3JMG0EUy2KZjl1p1ZUQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+85	Yes	10003752-FqtU5KNLv061y4uCTocNUg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+83	No	10008204-M89sn5FfBk2esA3f5ewsNg	Not Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+32	No	10008204-LF2lsh0eF0i6LP5fhnZK6g	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+67	No	10003752-Ni9QBx4EkC4n8ayG8gA	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+20	Yes	10000364-1476951	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+85	Yes	10000364-1320447	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+28	No	419639-011481	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	No	514382-034202	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	No	514382-037956	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+33	Yes	10022779-fFncIZp00umlmPZUwqwtA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+46	Yes	514382-011124	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+72	No	419639-001852	Not Hispanic or Latino	Asian	Male	CT	FALSE	TRUE	FALSE	FALSE
+55	No	514382-033797	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	10003752-1eHjPVJhUkmbL00SrNPMEw	Not Hispanic or Latino	Black or African American	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+55	No	514382-038052	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	No	514382-035561	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+39	No	419639-005343	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	No	514382-035478	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	No	419639-001191	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	419639-010716	Not Hispanic or Latino	Not Reported	Not Reported	DX	FALSE	FALSE	TRUE	FALSE
+55	No	10003752-l1rwt6mVkES8XqquIhhpyw	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+52	Yes	10000364-1214375	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	No	419639-004429	Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+51	Yes	10000364-1880956	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+39	No	514382-037032	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+14	No	10000364-1238807	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	No	419639-003662	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+57	Yes	514382-008241	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	No	514382-041506	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	514382-008960	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	10000364-1524198	Not Hispanic or Latino	White	Female	"CT, MR"	FALSE	TRUE	FALSE	TRUE
+61	No	514382-035343	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	514382-005123	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+86	Yes	10022779-BqGlLrjKf0T7iomPhuZUA	Not Hispanic or Latino	Black or African American	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+67	No	419639-011007	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+60	Yes	10000364-6610871	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+34	No	10008204-KHjBuBPW3EWlx6bbN7RolQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+85	Yes	514382-012330	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+84	Yes	514382-005297	Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	10000364-1488089	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+90	Yes	10000364-5761729	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	No	419639-012506	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+81	Yes	10008204-fwWb2jcffUqXfUeWo0WNyQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+88	No	514382-039408	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	10000364-149068	Not Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+89	Yes	10008204-jvhzOPDU00qXYWv7rLxCg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+26	No	419639-005633	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	419639-012199	Not Hispanic or Latino	Not Reported	Male	"DX,CT"	FALSE	TRUE	TRUE	FALSE
+57	No	10008204-nCrBfbnkUK9lEK3yEgIdA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+66	No	419639-010811	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+34	Yes	514382-013489	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+85	No	514382-017518	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+53	Yes	514382-007217	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+86	No	514382-015804	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+87	No	10008204-dUZBx3l6PkmvGeWPIZ5Qw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+74	Yes	10022779-38F9nIBB6kuVfCFoWagVmw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	No	10008204-ag2LuCv9YU62h5MOQZOoUg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	10000364-5484661	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+47	No	419639-000201	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+52	No	10000364-1763507	Not Hispanic or Latino	White	Male	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+46	No	419639-012051	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	No	419639-006869	Hispanic or Latino	Not Reported	Female	CT	FALSE	TRUE	FALSE	FALSE
+71	No	419639-005431	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	No	514382-038834	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+36	Yes	514382-002759	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	No	419639-002514	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	Yes	10022779-qeMdJJjjLE2EfIUopyYM6A	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+22	No	10003752-R3jwHaDB106Uvx4wcZCHWQ	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+61	No	419639-006304	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	419639-010537	Not Hispanic or Latino	Not Reported	Male	"CT, DX"	FALSE	TRUE	TRUE	FALSE
+43	Yes	514382-011811	Not Reported	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+43	Yes	514382-006750	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+23	No	514382-015835	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+48	Yes	10003752-5bWYK3ckxkulL8zRc7c1g	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+22	No	514382-035899	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+39	No	419639-008310	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	No	10000364-2409434	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+44	No	419639-000314	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+61	No	419639-004008	Not Hispanic or Latino	White	Female	"CR,CT,DX"	TRUE	TRUE	TRUE	FALSE
+25	Yes	10000364-2109824	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+80	Yes	514382-008422	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+84	No	10008204-t3dLQLrmv0Gvw8ZgHKBnQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+71	No	10000364-6094741	Not Hispanic or Latino	White	Female	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+62	No	10000364-6527933	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	10000364-1389953	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+66	Yes	514382-010684	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+83	No	10008204-osKWM1pRfUGOCSsdPI10g	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+45	No	419639-000528	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+55	Yes	514382-009579	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+78	No	10000364-1598970	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+62	No	419639-003225	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	No	419639-008992	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+29	No	419639-002259	Not Hispanic or Latino	Native Hawaiian or other Pacific Islander	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+62	Yes	10022779-Uhw4WyktMEeJ7qcjL42MQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+81	No	514382-016522	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	514382-003702	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+890	No	514382-034670	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+32	Yes	514382-012367	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+88	No	419639-001205	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+55	No	10000364-1584150	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	10003752-WkZVWZEXi0qL4jelZXi7yg	Not Hispanic or Latino	Black or African American	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+77	No	10000364-5290223	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+44	Yes	514382-003825	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	514382-014177	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+49	Yes	10022779-S0rIksdPoE2SYb4UWf2VbA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+32	No	10008204-bQExfBLeUSpuhX3UsPK1A	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+55	No	514382-014429	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+90	No	10000364-841928	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	Yes	514382-014092	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	No	419639-009261	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+23	Yes	514382-002168	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+53	No	419639-007651	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	No	419639-012010	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+23	No	514382-039746	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	No	10000364-1745774	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	514382-006563	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	No	514382-037878	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	No	514382-040098	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+39	No	10000364-1201874	Not Hispanic or Latino	White	Female	"CR, DX"	TRUE	FALSE	TRUE	FALSE
+88	No	514382-034916	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	514382-012292	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+27	Yes	10022779-D1fvlumekqp3hkE6Qtfrg	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+65	No	10000364-6410988	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	Yes	514382-011296	Not Reported	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+32	No	10000364-1517928	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+33	No	10008204-sTrNjK5kuH7M4lyTayjg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	No	514382-014964	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+36	No	419639-000485	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+26	No	514382-017342	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	10000364-1432081	Not Hispanic or Latino	White	Female	MR	FALSE	FALSE	FALSE	TRUE
+85	No	419639-005958	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+75	Yes	514382-002464	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+37	No	514382-014898	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+34	Yes	10008204-zu3TWtxyzkagrYDn0lMqxQ	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+72	Yes	514382-006727	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+77	Yes	10008204-BljmMyqLoEi1I2vnPtdWQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+72	Yes	419639-010024	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	Yes	514382-007607	Not Hispanic or Latino	Black or African American	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+86	Yes	10022779-GHagsnSuBEqnkD5RNZUJyg	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+61	Yes	10022779-fIVoBfAU9EqwLDAn97UA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+24	Yes	10022779-qCtP4V123US0cXExbhIEVg	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+47	Yes	514382-005400	Not Reported	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+54	No	514382-014531	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	No	514382-014804	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+77	Yes	10000364-1511917	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	Yes	514382-005614	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+86	No	10000364-5906252	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+49	No	514382-041468	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+52	No	10008204-qn5wSrf160ORVseGywmD9w	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+43	No	419639-004015	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+52	No	419639-009391	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	10022779-LEGoCVRs2E6Pb0iApohsXA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+63	No	10008204-6Xkngr7kjU78BlOTQN8jw	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+83	No	514382-017676	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	10000364-2102586	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+19	Yes	10022779-29MIeiXCEkCgyDswUv8OQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+52	No	10000364-2611377	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+54	Yes	10000364-1400306	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+27	Yes	514382-010705	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	No	514382-039775	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	10000364-1734557	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+78	Yes	514382-003681	Not Hispanic or Latino	Asian	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+34	Yes	10022779-XcQW20HjQUm9AXY6ANGscw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+68	No	514382-034120	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	No	10008204-J5I6jrVACk6iofMVxH1jAw	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+23	Yes	10008204-Q5aROXofUy2SsuhM0b0BA	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+83	No	10008204-0FQHdJYnZk6dp9DXczaog	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+52	Yes	514382-000403	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	10022779-JaPKE95uJ0GAJD13rV3LDw	Not Hispanic or Latino	American Indian or Alaska Native	Male	CR	TRUE	FALSE	FALSE	FALSE
+58	Yes	514382-007714	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	514382-013718	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	No	514382-035321	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	514382-000998	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+79	No	10008204-TflDKwrurU2ZkDTMxS7mPg	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	514382-012442	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	514382-007702	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+14	Yes	514382-002860	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+33	Yes	419639-009976	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	10000364-1580851	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+66	Yes	10000364-1410202	Not Hispanic or Latino	White	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+77	Yes	10022779-w4xLMy2DYU96U3rmZrjQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+79	Yes	10000364-814881	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	No	10003752-T0p2I9bi3UK89ian4IGPXA	Not Hispanic or Latino	Black or African American	Female	"CT, CR"	TRUE	TRUE	FALSE	FALSE
+72	Yes	10000364-1257770	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+65	No	419639-002703	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	10008204-1vFLNMBYSEi1c0RK0z0sJQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+43	Yes	10003752-HJ5LaBmknMkHaHtT3A	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+56	No	514382-034838	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	No	514382-038937	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+72	No	514382-017215	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	Yes	514382-004439	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+52	No	514382-018234	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	514382-005193	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+72	No	514382-034611	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+34	Yes	514382-010421	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	No	10003752-fDRY0kxkEaN1h9DgzVDkA	Not Hispanic or Latino	Black or African American	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+65	Yes	514382-007888	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+90	Yes	10000364-1502697	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+16	Yes	514382-005348	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+58	No	10000364-1127259	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+48	Yes	419639-004019	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	10003752-l858KeGMR0625envER0lUA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+47	No	514382-040187	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+83	Yes	514382-004259	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	10003752-aVvjOYYdWkyra6wiKyXGMg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+68	Yes	10000364-1705068	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+45	Yes	10000364-1505492	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+58	Yes	10003752-hAvtVithekOb9i3j0JuIQw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+49	No	10008204-MfACdRRsTEe5VHzwE1wIaQ	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	No	514382-037747	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+90	No	419639-010551	Not Hispanic or Latino	Not Reported	Female	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+66	Yes	514382-007087	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+37	Yes	514382-008646	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+28	Yes	419639-012035	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+78	Yes	10000364-5311482	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	No	10000364-5755124	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+55	No	419639-009775	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+75	No	10000364-467020	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+67	Yes	514382-002484	Not Hispanic or Latino	Black or African American	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+68	No	514382-037670	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+48	Yes	514382-009196	Not Hispanic or Latino	Black or African American	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+48	No	419639-000290	Not Hispanic or Latino	Asian	Male	MR	FALSE	FALSE	FALSE	TRUE
+66	No	514382-038828	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+65	No	514382-039799	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	Yes	514382-000588	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	No	10000364-5443907	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+87	Yes	10003752-ziJvzREjokWISm7GIxiysw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+69	Yes	10003752-PXcXkuCN50G2LQtkmMaibg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+45	Yes	419639-011864	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	10000364-6374574	Hispanic or Latino	Not Reported	Female	CT	FALSE	TRUE	FALSE	FALSE
+32	Yes	514382-006363	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	No	419639-009638	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+30	Yes	514382-001294	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	No	10003752-nlqwn0dTU02yzSBhPAcT0g	Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+61	No	514382-038109	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	10022779-HG4JHB7LQkqfKEMUVq0w	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+67	Yes	419639-006632	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	No	514382-016595	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+86	Yes	10003752-RtYN7HC5tUS8QbKrF1guA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	No	419639-009858	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+20	No	419639-002138	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+46	No	419639-003750	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	No	514382-015612	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+87	No	10008204-J8UWzgUXUuAekgejLeHIg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+63	No	419639-011554	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+34	Yes	514382-001774	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+2	No	10000364-6483209	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+51	No	10000364-6525281	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+16	Yes	514382-005397	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+65	No	419639-003148	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+52	Yes	10003752-VfYKdCbAfk21HtCO4m7l1A	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+27	No	10000364-5334567	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+44	Yes	514382-004180	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+84	No	10008204-v6kN1k6re0mC73osbOPQkA	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	10000364-2431606	Not Hispanic or Latino	Native Hawaiian or other Pacific Islander	Male	CT	FALSE	TRUE	FALSE	FALSE
+52	Yes	10000364-2016140	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+30	Yes	10022779-Qp5jOo4TL0SfjyMBGJWLCA	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	514382-001718	Not Hispanic or Latino	Black or African American	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+57	No	419639-005760	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+26	Yes	514382-000550	Hispanic or Latino	Other	Female	CR	TRUE	FALSE	FALSE	FALSE
+67	No	10008204-NGjxgegtC0iURsAOHsIDCw	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+73	Yes	10000364-1145020	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+890	No	10008204-GqWFGewWMEajQUni7T0CFA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+28	Yes	419639-011543	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+19	Yes	514382-011741	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	514382-003245	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	Yes	419639-006656	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+31	No	419639-005844	Not Hispanic or Latino	Asian	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+58	No	514382-037726	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+19	Yes	10003752-WymOOimJp02IuUo27m0ow	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+60	No	514382-016140	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+45	Yes	514382-007202	Hispanic or Latino	Other	Female	CR	TRUE	FALSE	FALSE	FALSE
+36	Yes	514382-012003	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+83	Yes	514382-007046	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+84	No	419639-006228	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	No	10022779-XdD4m32TEikBRQ49mY2TQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-033733	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+53	Yes	514382-008143	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+74	No	419639-004809	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	419639-009953	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+18	No	419639-003525	Hispanic or Latino	Not Reported	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+90	No	419639-001701	Not Hispanic or Latino	Asian	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+73	No	514382-041057	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+84	No	419639-004282	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+68	Yes	10022779-Jsiz0IdADEaebfgwBSwACQ	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	10000364-5447138	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+81	No	419639-000370	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+87	No	514382-035046	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+65	Yes	10000364-1608765	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+36	Yes	514382-010110	Not Hispanic or Latino	Black or African American	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+70	No	419639-006069	Hispanic or Latino	Not Reported	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+35	No	514382-015780	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+45	Yes	10003752-5v5AXcmk0WGQLMPB4JMjg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	514382-004048	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+25	Yes	514382-001961	Hispanic or Latino	Other	Female	CR	TRUE	FALSE	FALSE	FALSE
+56	Yes	10000364-2397286	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+52	Yes	514382-005928	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+34	Yes	10000364-2701885	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+30	No	10000364-1784636	Not Hispanic or Latino	White	Female	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+53	No	10000364-1593464	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	No	419639-005793	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+58	Yes	514382-003150	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+79	Yes	514382-010623	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+30	Yes	514382-001528	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+71	No	10000364-5945228	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	10022779-UIAWXKS5UE69aLZShXwFYw	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+72	No	419639-001053	Not Hispanic or Latino	Not Reported	Female	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+58	Yes	514382-005882	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+49	Yes	10000364-831177	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+72	No	419639-000941	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+63	Yes	514382-014031	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+32	Yes	514382-010751	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+24	No	10022779-BaIdHKrNYkmimZ4nrnbOzg	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+90	Yes	10003752-angip7tL0yinn7HPgtA	Not Hispanic or Latino	Not Reported	Male	"CR, DX"	TRUE	FALSE	TRUE	FALSE
+29	No	514382-016884	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+23	No	514382-039156	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+39	Yes	10000364-6632004	Not Hispanic or Latino	Asian	Male	CT	FALSE	TRUE	FALSE	FALSE
+55	Yes	10022779-l1nASHaVzUe9PnXRpih7A	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+28	No	10008204-tv7hBH5FVkiK7KN3C12A	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+81	No	419639-008741	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+40	No	514382-035303	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+41	No	514382-017060	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+50	No	514382-039591	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+49	No	419639-009029	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+26	No	514382-035134	Hispanic or Latino	Other	Male	CR	TRUE	FALSE	FALSE	FALSE
+90	No	10008204-F8hhmbYNSkGsZgwabUiGDw	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+73	Yes	514382-005119	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	10000364-5443794	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+58	Yes	10003752-ZiDNNhJz2055x9XsXLlHQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+85	No	419639-010122	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+78	Yes	514382-004363	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+23	No	514382-035652	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	419639-005650	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+21	Yes	10003752-WBrjTTgmk6RMILKvhWtA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+42	Yes	10022779-796Otyg41U2jVqaAeiG8IQ	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+48	No	419639-012486	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+69	Yes	10000364-1469759	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+73	No	514382-014736	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	419639-010002	Not Hispanic or Latino	Not Reported	Female	"DX, CR, CT"	TRUE	TRUE	TRUE	FALSE
+54	No	419639-002845	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	No	419639-003646	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+75	No	419639-000439	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+76	No	10000364-5357174	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	No	10000364-524136	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+84	Yes	514382-001954	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	No	10008204-HE0a4O71XUmv1JeRFZHB0A	Not Hispanic or Latino	White	Female	"CT, CR, DX"	TRUE	TRUE	TRUE	FALSE
+48	No	419639-011728	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+77	No	514382-016479	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+87	Yes	514382-002367	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	419639-010780	Not Hispanic or Latino	White	Male	"DX, CT"	FALSE	TRUE	TRUE	FALSE
+73	No	10003752-Lj14TodjkiiHkgZ5qeTWw	Not Hispanic or Latino	Black or African American	Male	"DX,CR,CT"	TRUE	TRUE	TRUE	FALSE
+63	Yes	514382-005163	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+54	No	514382-040227	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	419639-011616	Not Hispanic or Latino	Not Reported	Female	CT	FALSE	TRUE	FALSE	FALSE
+38	No	514382-036811	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	419639-012256	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+20	Yes	10003752-fz4O6MTB0iGS5ULVbKYA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+74	No	10003752-gGVLpnrnbk2o7pbw84IH1Q	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+43	Yes	514382-004963	Hispanic or Latino	Other	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+78	No	10003752-v2uvBXysYEG4VGo3K328lg	Not Hispanic or Latino	White	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+61	Yes	10022779-ap7Z9K3E0yQeZtsT23YrA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+76	Yes	10000364-5381683	Not Hispanic or Latino	White	Male	"CT, MR"	FALSE	TRUE	FALSE	TRUE
+58	Yes	10000364-574742	Not Hispanic or Latino	White	Male	"CR,CT,DX"	TRUE	TRUE	TRUE	FALSE
+35	Yes	10022779-nkB9ALZnyU2wAyAiMoVs0A	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+46	Yes	10022779-jlxbOEA0EOsC5wDBgReFQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	No	10000364-1580375	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	514382-005950	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+39	No	514382-035967	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	514382-007301	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+61	Yes	514382-001016	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+41	No	10000364-1494687	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+56	Yes	419639-010558	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	No	514382-018179	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+40	No	514382-034499	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	419639-009440	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+21	No	419639-003946	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	No	10008204-UPcMFoImAkyqvcVc3UnDDw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+54	No	514382-040995	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	10022779-qg1RImXttk2WyaQvaCEdqA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+27	No	10008204-yAiak1SfMEW7UNtmjIXIbA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+44	No	419639-011131	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+53	No	419639-002519	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+74	Yes	514382-012347	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	10000364-186213	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+41	Yes	514382-011376	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+36	No	419639-001919	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	10022779-jPZxbYoykGRRzTvNNqvxw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+57	No	10008204-kGk2JFE5D0SGOFTcJPbblA	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+40	Yes	514382-010026	Not Reported	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	514382-001304	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+86	Yes	419639-004368	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+24	No	514382-041409	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+52	No	514382-035326	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+26	Yes	10022779-KGpmR2EIxUuUbhSypJhkgw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+49	No	10000364-1601822	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	419639-006987	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+33	No	514382-034276	Not Reported	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	10022779-PVxxJOyhfkCZjpAVeG3vgw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+52	No	10008204-QVLR130NkyfAz05KwCbtA	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+71	No	514382-017530	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	514382-012777	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	10000364-2413454	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+58	No	10003752-JZ5vuNTSEuJUwIVHRJBhw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	No	10008204-4BNggfTuEihW7w1rZ8BRg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+45	Yes	10003752-gC5Vd15BUSM4j4xGwyGA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	No	514382-038560	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+29	Yes	10000364-1561189	Not Hispanic or Latino	Black or African American	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+90	No	10008204-OduOMxL8mkSGLvYPmUHJxg	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+39	No	10008204-heUH8ntotkSgnwPbNMCOA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+39	No	10022779-3tYGkR6xQ0u8UJu6Jc75sQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	10003752-2nESuxFpUKECwV8IY6BUQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+29	Yes	514382-013409	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+15	No	514382-017908	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+89	Yes	514382-002702	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+62	No	10000364-5238233	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+45	No	419639-000357	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	514382-013152	Hispanic or Latino	Other	Female	CT	FALSE	TRUE	FALSE	FALSE
+49	Yes	514382-006782	Not Hispanic or Latino	White	Male	"CR,CT,DX"	TRUE	TRUE	TRUE	FALSE
+74	Yes	10003752-UYbjxTMj1kWtPoftblbR0w	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	No	419639-008312	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+61	No	419639-001323	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+72	Yes	419639-008020	Not Hispanic or Latino	White	Male	"CT, DX, CR, MR"	TRUE	TRUE	TRUE	TRUE
+56	Yes	10000364-1714989	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+72	No	419639-008836	Hispanic or Latino	Not Reported	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+57	No	514382-017533	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+69	Yes	419639-006170	Hispanic or Latino	Not Reported	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+72	Yes	10000364-5549262	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+34	Yes	514382-006159	Hispanic or Latino	Other	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+42	No	514382-016912	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+86	No	10000364-875458	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+62	Yes	10022779-xy4sAUxzvUKhuBoka9W4g	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	10000364-817472	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+88	No	10008204-xAcOFieQ4kq8CMbbkyox3A	Not Hispanic or Latino	White	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+62	Yes	10000364-2690242	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+34	Yes	419639-008751	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+52	Yes	514382-000810	Not Hispanic or Latino	Black or African American	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+64	Yes	10000364-6604749	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+38	Yes	514382-012926	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	10008204-Dk652AeP3UenXhO4W52LiQ	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+72	No	419639-003227	Not Hispanic or Latino	White	Male	"DX, CT, CR"	TRUE	TRUE	TRUE	FALSE
+85	No	514382-036147	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+39	Yes	514382-010947	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	Yes	419639-007770	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+82	No	10008204-ov4LIUOkQk6lz2q5NdfCg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+34	No	10003752-1pHuLYLiMUWoqcp3B6Nhw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+60	No	419639-005563	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+68	No	514382-016207	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	10003752-AoRXp7Cd8EyQSVJnZp0vA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+1	No	10008204-YebCuDogU2OyjsftxX41A	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+34	No	10008204-q1VWe0OUCGokDOvnqp7A	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+43	No	10008204-Kn0Bz6Urvk68fX6PmUKokA	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	No	10003752-uoQAvHR5AkeNhdZrLaB7GQ	Not Hispanic or Latino	Black or African American	Male	"CR, CT"	TRUE	TRUE	FALSE	FALSE
+75	Yes	10003752-kcaIUeN02kThleoXT26g	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+78	No	514382-035306	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	514382-002684	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	514382-001965	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+64	No	10022779-t59znYTWGUu15i2usMRyFg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+63	No	10008204-FLrxrexKkep9ZdmqjWwQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	514382-005805	Hispanic or Latino	Other	Male	CT	FALSE	TRUE	FALSE	FALSE
+79	Yes	514382-006902	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	Yes	10000364-1483303	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+61	No	10000364-6167445	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+63	No	419639-011069	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	514382-010481	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+45	Yes	514382-008493	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	No	514382-040130	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+40	No	419639-006859	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+88	No	514382-034403	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	10022779-phAwYcpJiEGxHuHESh24pw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	No	10008204-JK3yyzZGBkGIZ4FuF9gw	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	10003752-wFvQEYq9aUu1Mz8UzYkMHg	Not Hispanic or Latino	Black or African American	Female	"CT,DX,CR"	TRUE	TRUE	TRUE	FALSE
+21	Yes	10000364-30394	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	No	10003752-oOo2uZIz0GM2JX2nqJz3g	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+78	No	514382-016897	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	419639-011624	Not Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+62	No	10008204-JYk51VGxSkK8ZJjd5hosOg	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+78	Yes	514382-006324	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+39	No	419639-006143	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+40	No	514382-015196	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	10022779-CrxVJcbOkCFTQmiLHj6lw	Not Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+47	No	10000364-1475640	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+72	No	514382-039139	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	10008204-84B30wAmTkupGFijIHeUBw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+52	Yes	514382-009105	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+46	Yes	10008204-gxZhb1SYuEuME5FG5Kuk1g	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+29	Yes	10000364-1710502	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+59	No	514382-039541	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+28	Yes	514382-014252	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+51	No	419639-005005	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	No	514382-017584	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+57	Yes	10003752-bUa2mjXjJE2o2FjV5YyQHA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+77	No	514382-034565	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+49	No	419639-006015	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+19	No	10000364-6414298	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+73	No	10008204-lcHjjBg4UmgtEnhWwGIQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+61	No	10008204-sZi0qDrpUK5eXhPEkIHsA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+77	Yes	10000364-1149782	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+82	No	514382-040230	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	514382-013028	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+77	No	419639-002582	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+66	No	514382-035712	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+27	Yes	10022779-2oUeGVbYp0uS3XJHvi1sg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+26	No	514382-041196	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+16	Yes	10022779-zy365MQqI06fpnUD1k5OQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+48	Yes	514382-004169	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+82	Yes	10022779-yfQAlAtW4kWV96aQQu1wuQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+67	No	514382-037328	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+28	Yes	514382-010031	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	No	419639-000281	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	419639-012138	Not Hispanic or Latino	Not Reported	Female	"DX,CT"	FALSE	TRUE	TRUE	FALSE
+20	No	514382-034817	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	514382-004112	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+57	Yes	514382-007452	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+84	Yes	10000364-2688483	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+27	Yes	10000364-6494692	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+20	No	10000364-1457820	Not Hispanic or Latino	White	Male	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+82	Yes	10000364-2574379	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+80	Yes	10000364-4964574	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+56	No	419639-001521	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+53	Yes	10000364-917276	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+29	No	419639-010072	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	514382-005231	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+83	No	10008204-ee5u7BS2eketpGGdL4FNcw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+48	No	10022779-AkmdM94H0EWz7z6NjwDfvQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	10000364-235921	Not Hispanic or Latino	White	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+65	No	514382-035257	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	Yes	10000364-1558656	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+26	No	10008204-rPcxWvt44Ea7Kxv7g2kTA	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	No	10008204-jlK2JAPWg0aw0GzHMx5r6g	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+39	Yes	10000364-1608565	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+43	No	10000364-1626234	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+73	No	10008204-FguYL4WlqEuyEcRjJpXQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+79	No	514382-041505	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+27	Yes	10003752-AZXAorsGYU23jKa3nHfGqw	Not Hispanic or Latino	Black or African American	Male	"CR, CT"	TRUE	TRUE	FALSE	FALSE
+51	Yes	10022779-6dhoJN6d0ibrVxRz4Dm5g	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+68	No	419639-002373	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+33	Yes	10022779-1JEG9Y6bxk2ahHWACVRQRA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	No	514382-016175	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+76	Yes	10022779-2UOM0CQl00G5GEesObomCA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+89	No	514382-038432	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	10003752-iGxDpJOZkGNPK9yEbVSgg	Not Hispanic or Latino	Black or African American	Female	"CR, DX"	TRUE	FALSE	TRUE	FALSE
+27	No	514382-041408	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+76	Yes	10000364-1234462	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+33	Yes	514382-008761	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+82	No	10008204-ozDvCHAuv0SI090Q8ah8Q	Not Hispanic or Latino	White	Female	"CT,CR,DX"	TRUE	TRUE	TRUE	FALSE
+49	Yes	10022779-so9zAHfjDEKZM4EqjpbrrQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+72	Yes	514382-004083	Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	10003752-zCZfCcUCeE2oyQSDwL2WUQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+34	No	514382-039081	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+29	Yes	514382-002043	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+40	No	10000364-91833	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+46	No	419639-004132	Not Hispanic or Latino	Native Hawaiian or other Pacific Islander	Male	CR	TRUE	FALSE	FALSE	FALSE
+72	Yes	514382-000210	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+29	Yes	514382-012935	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+78	No	10008204-y08DTr8CDE69AMGhT0r0ig	Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+66	No	514382-035781	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+80	No	10008204-yYiBc2RD0ii8aGSwt1UfQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+55	Yes	419639-009513	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	No	10000364-6106993	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	No	514382-039998	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	No	514382-039817	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+51	No	10000364-1188533	Not Hispanic or Latino	White	Female	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+41	Yes	10008204-xSPjG2Gj0SbGcNUjjDA	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+46	No	514382-039884	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+65	Yes	514382-005585	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	No	10008204-ADhwqOVpUaO5OLbFnnSaQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+29	No	419639-002026	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+66	No	514382-015841	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+68	No	419639-008912	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+90	Yes	10000364-1590393	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+79	No	10008204-69GHdUOpEqo8XC8qbWMg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+76	No	419639-001042	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	10000364-2608379	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+67	No	514382-038765	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	Yes	514382-001716	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+53	No	514382-016817	Not Reported	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	Yes	514382-012382	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+44	No	10008204-gpHTMf5V6Em7JUVRot9rag	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+55	Yes	514382-007990	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+49	Yes	514382-005237	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+33	No	10000364-1225405	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+78	Yes	514382-007700	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+57	Yes	10022779-UcP2tiaXG0efRdQKX7YNlA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+55	Yes	419639-012187	Not Hispanic or Latino	Not Reported	Female	CT	FALSE	TRUE	FALSE	FALSE
+86	No	10008204-kpAb9zrCWkSX4skMRE61HQ	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+51	No	419639-009176	Not Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+34	Yes	514382-010247	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+73	Yes	10000364-5459625	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+47	Yes	514382-005391	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+44	No	10003752-o4uoc1N4VEjpK07WfVY0A	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-037208	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+22	No	419639-011387	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+68	No	419639-004992	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	No	514382-035800	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+67	Yes	10022779-ApJPyaoWHkmYveJkZUSwA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	514382-004246	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	No	10000364-5567172	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+48	No	419639-005914	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+48	No	10000364-1543929	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+46	No	419639-003130	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+43	No	10000364-505166	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+76	No	419639-012049	Not Hispanic or Latino	Not Reported	Male	"DX,CT"	FALSE	TRUE	TRUE	FALSE
+40	No	514382-014617	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	514382-002641	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+49	No	419639-005286	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	No	10008204-JuDT8qWp0e8EPqCEb79dA	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+44	No	514382-037563	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+78	No	514382-041079	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+27	No	514382-036901	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	10000364-5853068	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+41	No	10003752-lxesBHpkVky3RkXuVKK0w	Not Hispanic or Latino	Black or African American	Female	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+60	No	419639-012500	Not Hispanic or Latino	Not Reported	Female	"DX,CT"	FALSE	TRUE	TRUE	FALSE
+74	No	10008204-2iLWHSoLz0GRQvFemJZsA	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+87	No	514382-039320	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+66	No	10008204-LSnjJ7H9P06ZyHtFcSw9g	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	No	514382-015593	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+48	No	514382-037662	Not Reported	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	10000364-5505581	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	514382-007945	Not Reported	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+41	Yes	514382-013400	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	514382-000317	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+72	Yes	10022779-ZJhFBjZLfE6mlPWdBhDIw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+83	Yes	514382-009431	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+81	Yes	514382-006097	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+69	No	514382-035759	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+90	No	10003752-pkvcQg9IH0WRfsdzZ77kg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+34	No	10008204-EAyqUMvLUUa4KJSK306zvQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+31	Yes	419639-008814	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+66	No	10008204-LMWwVKLzzUOSCe5jA5G0ow	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+84	Yes	514382-011942	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	419639-008592	Not Hispanic or Latino	Other	Male	CT	FALSE	TRUE	FALSE	FALSE
+79	No	514382-034066	Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	No	419639-003206	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	Yes	10000364-1544329	Not Hispanic or Latino	Black or African American	Female	"CTPT, CT"	FALSE	TRUE	FALSE	FALSE
+79	No	419639-004447	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+48	No	10022779-VbG0HPp002uR8bgQvXx6w	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+77	Yes	514382-000022	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+82	No	514382-040471	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+77	Yes	10000364-5232757	Not Hispanic or Latino	White	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+90	No	419639-002664	Not Hispanic or Latino	Black or African American	Female	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+73	No	514382-035593	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+21	Yes	10000364-1392428	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	10022779-zMRy8vCrVk6hKzpDeKfuAA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+44	No	514382-015755	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+73	Yes	10000364-2065879	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+65	No	514382-036939	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	No	514382-040577	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	Yes	10003752-oYVegOGzvUt38KcnFJww	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+63	Yes	10022779-R7ULscaRI0G2Oi2Mc1Vg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+71	No	10008204-XGsWaJmZKEW5nkS3vanCBg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+35	Yes	514382-003147	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+52	Yes	514382-004424	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	10000364-6551596	Not Hispanic or Latino	White	Male	MR	FALSE	FALSE	FALSE	TRUE
+58	Yes	514382-009417	Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+28	Yes	10000364-1370275	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+32	No	419639-002907	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	No	10000364-5586899	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+42	No	10000364-6000792	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+74	No	419639-006046	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	514382-010759	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	514382-003545	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	10008204-G4cUbCJS9EuoNhaR2DwOw	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+63	No	419639-001371	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+43	No	419639-000245	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+7	Yes	10000364-2364844	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	No	10000364-1526504	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+78	No	419639-004991	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+77	No	514382-040100	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	No	419639-004346	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+51	No	419639-005656	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+87	No	419639-004421	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+88	No	10008204-OlKfv1C4skmyX0EHNtnxA	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+48	No	514382-040045	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	10022779-Kw6P9DzLECvZTxzUU8c8g	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+19	No	10008204-3EQVv41QUidR7A0ljWzvQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+38	No	419639-007629	Not Hispanic or Latino	Other	Male	CT	FALSE	TRUE	FALSE	FALSE
+43	No	419639-006472	Hispanic or Latino	Not Reported	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+71	No	10022779-IWi3iiyV40ygrL8kfTn6xQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	Yes	514382-008810	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	Yes	10022779-9B0mOefECkOSqVlkvBliw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+87	No	514382-034255	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	No	10008204-Q4U4JZMMWEM7PPsVSqWg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+52	No	514382-040921	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	No	10008204-raRXWK84L0KZrPghyXTyQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+48	No	419639-005026	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+10	No	10000364-1711752	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+64	Yes	10000364-1514443	Not Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+66	Yes	10022779-N5tDk3pU0KrSTv95rGVJw	Not Hispanic or Latino	Black or African American	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+79	No	514382-016375	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+57	No	419639-001051	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+41	Yes	514382-003225	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	No	514382-036369	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+36	Yes	10022779-tIUhuVAxEiTezIqw2dXtQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+87	No	419639-008236	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+84	No	419639-010071	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+39	No	419639-003351	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	10000364-2400569	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	514382-012667	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	Yes	10000364-5427913	Not Hispanic or Latino	American Indian or Alaska Native	Female	CR	TRUE	FALSE	FALSE	FALSE
+56	No	10008204-BAKjuquAOUaIzTm33Zx84Q	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	No	514382-039164	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	10003752-bUeY8GTlzkOVyNvgAuwn4g	Not Hispanic or Latino	Black or African American	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+66	Yes	10000364-1722837	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+20	Yes	10000364-5595375	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+58	No	419639-008473	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	10000364-6457917	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+22	No	419639-001715	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	419639-010353	Not Hispanic or Latino	Not Reported	Male	"DX, CR, CT"	TRUE	TRUE	TRUE	FALSE
+61	No	10000364-1068666	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+56	No	10003752-MojpBGJVZ0u3qseqcbaN3w	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+70	Yes	10000364-1819907	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+14	No	514382-015109	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+46	No	419639-009611	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	10000364-485319	Not Hispanic or Latino	White	Female	"MR,DX,CT"	FALSE	TRUE	TRUE	TRUE
+85	No	419639-001281	Not Hispanic or Latino	Asian	Male	CT	FALSE	TRUE	FALSE	FALSE
+33	No	10008204-zg5BhN4IpUOerMHI8Ns9gA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+69	No	10000364-1541818	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+68	No	419639-006736	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+59	No	514382-016465	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+21	No	10008204-zQn4Zu2PU2HokUs9vw5xQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+52	No	10022779-yBykLPpEuEWPriVY1S2g	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+57	No	419639-008026	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+55	No	419639-006409	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+40	No	514382-034263	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	No	10000364-1008859	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+67	No	514382-034777	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+24	Yes	514382-005059	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+36	Yes	10022779-M6b1wqzGME5ud8wMiEMw	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+49	Yes	514382-010243	Not Hispanic or Latino	Other	Male	CR	TRUE	FALSE	FALSE	FALSE
+49	No	419639-002288	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+27	No	419639-004002	Hispanic or Latino	Not Reported	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+64	Yes	10000364-1024386	Not Hispanic or Latino	White	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+48	No	514382-035085	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+72	No	514382-016000	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	10003752-nV3gZ9iJB0KUdz65xqkUg	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+72	No	419639-005437	Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+82	Yes	514382-008090	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	10000364-893521	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+27	No	514382-014635	Not Hispanic or Latino	Black or African American	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+39	Yes	514382-009017	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+70	Yes	514382-005534	Not Hispanic or Latino	White	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+58	Yes	514382-005327	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+52	Yes	10000364-986870	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+62	Yes	10000364-2368698	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+80	Yes	514382-005132	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	514382-007210	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+87	No	10008204-hozU7Z5LwU2rA2WGk3fuNg	Not Hispanic or Latino	White	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+52	Yes	10000364-5405683	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+5	Yes	10000364-2715598	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+90	No	10008204-FpyKUJhz1UXCT1FTQoIg	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+29	No	419639-009736	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+79	No	10008204-B6kK7gLPECNbvY35j5Kw	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+80	Yes	10008204-PNqy4yDtsE2OdTJVoUdzWg	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+78	Yes	10003752-rvwMVu5suESuSYzbEH2BkQ	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+46	Yes	514382-005169	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	No	514382-040567	Hispanic or Latino	Other	Female	CT	FALSE	TRUE	FALSE	FALSE
+90	No	419639-001151	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+42	No	10008204-o1VV400If0K1vMFIrL5Zw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+46	Yes	10000364-5370935	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+41	No	10008204-haYQRevLrkqIsndVJ0N1zg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+61	No	10022779-AGvV9ApxkmgN3HBtRao7A	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+47	Yes	514382-008830	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	514382-008296	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+28	Yes	514382-002529	Not Reported	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	10022779-IiQHTqmHV0GzsH8XyNt1Yg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+68	No	10000364-1325950	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+78	Yes	514382-006649	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+82	No	514382-038316	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	514382-004641	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+21	No	10008204-iu5Ds3kDHkeCuCKB0zfONQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+34	Yes	10022779-gcaTXS9eM0CXMXANF4F11g	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+36	No	419639-009352	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+60	Yes	10022779-gJf2H2IvZkGXo5X1EUA	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+21	Yes	514382-007460	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+43	Yes	514382-013432	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+39	No	419639-000860	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+37	Yes	10008204-0KSgQdTRMkGETmHMW6Cl7g	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+46	Yes	514382-011172	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	514382-007388	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+36	No	10003752-be7JwuDhyUCNzMr6D1l7jg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+78	No	514382-038247	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	No	419639-010707	Not Hispanic or Latino	White	Female	"CR, DX, CT"	TRUE	TRUE	TRUE	FALSE
+44	Yes	514382-009506	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	No	514382-038143	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+42	No	514382-014980	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+80	No	10008204-jwzjQr1pvkqA3ynbduZidQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+54	Yes	10000364-1333560	Not Hispanic or Latino	Black or African American	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+82	No	10008204-ADZSn8k02kG5zyDVWPYKQ	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+69	No	10000364-1468884	Not Hispanic or Latino	White	Female	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+20	No	419639-003460	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+75	No	10008204-Gidppxmmk6jLH5ZGzL3g	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+85	No	419639-011280	Not Hispanic or Latino	Not Reported	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+47	Yes	514382-006995	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+43	Yes	514382-004594	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+81	No	10003752-QWdtJUvESwP0lTNCHkbQ	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+70	No	419639-000512	Not Reported	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+40	No	419639-003414	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	10003752-u4AEaqARTkC2eONwTIEBbw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+23	No	514382-016414	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	514382-034191	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+90	Yes	10008204-gFXS4Spa1USn011gSjaEg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+55	Yes	419639-010186	Not Hispanic or Latino	Not Reported	Female	"DX, CR"	TRUE	FALSE	TRUE	FALSE
+69	No	10003752-xyzQz38AjUeUiL2iypkUMw	Not Hispanic or Latino	White	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+43	Yes	514382-007711	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	Yes	514382-013602	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+57	No	419639-000702	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+24	Yes	10003752-tEMq3HgNkWSnvK2Nsh1OQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+34	Yes	10022779-DFkZXnh6XU2k4oftUBYjw	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	No	514382-035742	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	10003752-MlFD0vk0XESdG6ckXFJA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+72	No	419639-006961	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	514382-003222	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+85	No	10003752-l3K0ezZJD0K9OFTBJOfJpQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+76	No	10000364-2100556	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+66	Yes	514382-013217	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+40	Yes	514382-007589	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+65	No	10008204-oLR6EIQfF0uIHQQ4y2Atkw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+36	No	419639-002570	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	10003752-KxY8Kf71S0Kqu4uy1LUD1w	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+74	No	514382-034055	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	10000364-17577	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+90	No	10008204-rmUwMddCkUCxgNqELAQ	Not Hispanic or Latino	White	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+37	No	419639-006966	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+80	Yes	514382-003557	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+84	Yes	10003752-9oEEzVxJtUhU1aSCMfuXQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+61	No	10003752-8npOYNRs0OLjtwjXtlLuQ	Not Hispanic or Latino	Black or African American	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+53	Yes	10022779-DdjB87oRbECrKRS5695rw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+82	No	514382-017397	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	No	419639-002878	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+81	No	419639-001221	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+85	No	514382-040397	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	No	514382-017988	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+78	No	419639-011991	Not Hispanic or Latino	White	Female	"DX,CT"	FALSE	TRUE	TRUE	FALSE
+37	Yes	514382-013433	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	No	514382-037745	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	No	10000364-1489746	Not Hispanic or Latino	Asian	Female	CT	FALSE	TRUE	FALSE	FALSE
+77	Yes	10022779-nxcJf0wPskC98JzSxf8GA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+48	Yes	514382-013670	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+59	No	10008204-tQESjOuMqUSk0XGjwdY8w	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+86	No	10000364-1469626	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+52	No	10008204-xMMtBstBW0iz6GLVeJKmw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+67	Yes	10003752-oNtIFxg7G0inyYJV6hkCyg	Not Hispanic or Latino	Black or African American	Female	"DX,CR,CT"	TRUE	TRUE	TRUE	FALSE
+32	Yes	419639-007594	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	10022779-WlMZONnckSH5gcwT33esg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+55	Yes	514382-013797	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+11	No	10000364-6563807	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+46	Yes	514382-009890	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+61	No	514382-017228	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+79	No	10008204-PBar8RBl0aVWgJ7NLL6fg	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+64	Yes	514382-003752	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	No	419639-009767	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+41	No	10000364-1211458	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+70	No	10008204-XtLqBh0hYEqsX3YUnWbadg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+68	Yes	514382-002458	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	Yes	514382-012203	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+39	Yes	514382-009625	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	10000364-6593463	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+67	No	10000364-2067146	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+74	No	10008204-fLUB8i2yT0u3sjPVxVs4YQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	No	514382-015379	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+89	Yes	10000364-2443143	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+66	No	419639-001700	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+19	Yes	10003752-C9iZJjc60SZKil4XzgIfg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+56	No	514382-014673	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+20	Yes	10000364-6501726	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+53	No	514382-035842	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+84	No	419639-007393	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	No	419639-001606	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	514382-007615	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+59	No	10000364-2451946	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+52	No	514382-036382	Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	No	419639-009591	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+31	No	10000364-2720246	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+21	Yes	514382-007667	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	No	514382-037414	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+19	No	419639-001402	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+44	Yes	10022779-SMt8YaJwxUe7aLE2AShbZQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+48	Yes	514382-010403	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+85	No	419639-003192	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	514382-034957	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	No	10008204-gDvZ9K7DZUChKBNd93cNaQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+45	No	419639-000640	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+43	Yes	10000364-1613247	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+43	Yes	10022779-qlYGiXnyUSPSu4BZf88g	Not Hispanic or Latino	Black or African American	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+74	No	514382-035267	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+22	No	10022779-fmHkHBr9DU6CYgcwon4Reg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	No	10000364-1451883	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+62	Yes	419639-000906	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+34	No	419639-002167	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	514382-012485	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+79	No	514382-035523	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+78	No	419639-006363	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	Yes	10000364-1004161	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+34	Yes	514382-008182	Not Hispanic or Latino	Black or African American	Female	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+71	No	514382-015533	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	No	514382-015520	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	No	10000364-1039916	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+74	No	419639-010562	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+53	No	419639-006084	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+60	No	419639-001834	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-014511	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+84	Yes	10000364-1459766	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	No	10000364-1493253	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+46	Yes	514382-005174	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+73	Yes	10000364-2007066	Not Hispanic or Latino	American Indian or Alaska Native	Male	CT	FALSE	TRUE	FALSE	FALSE
+68	Yes	514382-008489	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+26	No	514382-015315	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+43	Yes	514382-001628	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+53	No	10008204-M0ou6vWo4kmaTWsnMGEyug	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+72	Yes	514382-003907	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+27	No	10008204-wJ2sanQuDEKvtTvTFvRDXQ	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+62	No	10008204-o0IJm2hkt0mWemcx8lrOew	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+73	No	419639-010795	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+31	Yes	10000364-6093707	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+43	No	419639-010360	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+63	No	419639-002364	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	10022779-2egkU734vk2JNDK70rHIIQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+57	Yes	10000364-2722648	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+62	No	514382-016086	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+64	Yes	10022779-6KWu7xZcZkKxXTEk1dmI1Q	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	514382-002731	Not Hispanic or Latino	Black or African American	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+27	Yes	10022779-VSVv9iqr8ESDbiuQFSv5xw	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+35	No	10008204-1EFIedKBEUymvFcdycUSQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+43	No	419639-000967	Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+77	No	419639-004920	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+65	No	10008204-YQDaX5FSZEWxWtsKEK77wA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+70	Yes	10022779-F9hCUWwc0aJ2KSbUr6xA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+81	No	514382-034214	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+82	Yes	514382-008116	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+58	Yes	10000364-5410015	Not Reported	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+88	Yes	514382-012130	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+58	No	419639-009151	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	No	514382-037715	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-040262	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	514382-004969	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	No	10000364-6599973	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+80	Yes	514382-000545	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	Yes	514382-002139	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	10000364-1142407	Not Hispanic or Latino	White	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+50	Yes	514382-001990	Not Hispanic or Latino	Black or African American	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+38	No	419639-012388	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+37	Yes	10022779-7FgcUbP0kiHZekUnXXQ3w	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+28	Yes	419639-008379	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+54	No	514382-016142	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	Yes	10022779-FqPHAKtzUe5VtBSUwIMA	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	10022779-w6BiNfsU4U6Po1crtw1a8w	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+73	No	514382-035938	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	514382-002212	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	514382-004273	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	10000364-6591268	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+48	No	419639-010414	Not Hispanic or Latino	Not Reported	Female	"CR, CT, DX"	TRUE	TRUE	TRUE	FALSE
+42	Yes	419639-009153	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+53	Yes	514382-013223	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	10022779-INVKAmbhVUCPUaU8D5nyuQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+84	Yes	10000364-1459686	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	10000364-1318998	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+90	No	419639-007483	Not Hispanic or Latino	Other	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+34	No	10000364-6602412	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+80	No	419639-009565	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	No	10008204-9lHroMgLgU2Mcga45pSLpQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+50	Yes	10000364-5314260	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+59	Yes	514382-012505	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+53	No	10000364-1598197	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+47	Yes	514382-007893	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	No	514382-015437	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+69	No	419639-007238	Not Hispanic or Latino	American Indian or Alaska Native	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	514382-000958	Not Hispanic or Latino	Black or African American	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+76	Yes	10022779-bKelKUNGDEiPtUKvqAdlPA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+58	No	514382-040273	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	No	419639-004899	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+65	Yes	514382-009992	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	514382-004819	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+26	No	514382-039538	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+14	Yes	514382-001310	Not Reported	Other	Male	CR	TRUE	FALSE	FALSE	FALSE
+86	No	514382-014851	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+36	Yes	419639-010534	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+78	No	514382-040835	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	No	10008204-IRxL50i6EmpH36sRj990A	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+54	Yes	514382-008326	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+73	Yes	10000364-1561914	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+47	Yes	10003752-p4paodp0OkeBa8hOTNFUA	Not Hispanic or Latino	Black or African American	Male	"CR, CT"	TRUE	TRUE	FALSE	FALSE
+39	No	419639-001204	Not Hispanic or Latino	Other	Female	CT	FALSE	TRUE	FALSE	FALSE
+50	No	514382-034170	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	10000364-1946854	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+54	No	419639-000359	Not Hispanic or Latino	White	Female	MR	FALSE	FALSE	FALSE	TRUE
+78	Yes	10000364-1730466	Not Hispanic or Latino	White	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+64	Yes	10008204-lqwi35CjE6He4lDnSlfcw	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+53	No	419639-010884	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+56	No	10008204-ypTYszRMgEe2nfPDzeNnuw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+32	No	10008204-ZituZtcWzEmmiCLEgRGklw	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+39	Yes	514382-001525	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+57	No	419639-003330	Not Hispanic or Latino	Other	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	No	419639-009943	Not Hispanic or Latino	Asian	Female	"CT, DX"	FALSE	TRUE	TRUE	FALSE
+60	Yes	10000364-1321558	Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+68	Yes	10003752-kSQb21LHdkiPnsMLl4FG5Q	Not Hispanic or Latino	White	Female	"CT, CR"	TRUE	TRUE	FALSE	FALSE
+71	No	10008204-uFA2GSbrmUqb4bjtcLSLrA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+66	Yes	514382-007959	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+77	No	514382-035341	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	No	10000364-1457502	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+65	Yes	514382-013957	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	Yes	10022779-C8VI7YT0MUKOOxwvi4KHA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+23	Yes	10022779-lHqkdqGmEuNnDDElssfw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+90	No	419639-009100	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	No	514382-036691	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+66	No	419639-001181	Not Hispanic or Latino	Asian	Female	CR	TRUE	FALSE	FALSE	FALSE
+72	No	419639-009160	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+59	No	514382-016832	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	10008204-rSvKAlDzS0OsHIqWwFW55g	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+25	No	10008204-XVF1NtU50GOXWeHKIbQ	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+62	No	419639-004594	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	No	10003752-ynnax8heZ0cbuEqZMOVg	Not Hispanic or Latino	Black or African American	Male	"CR, CT"	TRUE	TRUE	FALSE	FALSE
+56	No	419639-006092	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+67	Yes	10000364-5242561	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+50	Yes	10022779-AuJYF6wLUmLCvMcVOjtg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+88	Yes	514382-000599	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	No	419639-002244	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	10003752-02Z4o9ra0yXDNRFXE1fbg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+31	No	419639-001901	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+23	Yes	514382-003369	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	No	419639-012484	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+86	No	419639-007994	Not Hispanic or Latino	Asian	Male	CT	FALSE	TRUE	FALSE	FALSE
+76	No	514382-037355	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+53	Yes	10000364-1154964	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+23	Yes	514382-003855	Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+39	Yes	10008204-MnevmSBfK0Cpx3ywdQSAA	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+59	Yes	419639-011950	Not Hispanic or Latino	Not Reported	Male	"DX,CT,CR"	TRUE	TRUE	TRUE	FALSE
+43	No	514382-016187	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+890	No	10008204-Iq8ksqR0uRX1cLaXVdyA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+83	Yes	514382-013144	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+77	No	10000364-1609004	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+30	No	419639-002850	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+22	Yes	514382-007467	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+35	No	419639-002964	Not Hispanic or Latino	Other	Female	DX	FALSE	FALSE	TRUE	FALSE
+83	No	10000364-136440	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+83	Yes	10022779-JLQ7E5dAp06Ktvc6UVHfg	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+53	Yes	10022779-lQ1rmknUPkqZv9kN4W755Q	Not Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+78	No	514382-015414	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+83	No	514382-015710	Not Reported	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+41	Yes	10003752-TVpL2i0U0kSIRraATiqg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+56	Yes	514382-013354	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+85	Yes	514382-012141	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+64	No	10008204-xIx33zMJI0aWwXmWM26ZYA	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+28	Yes	10003752-xPfyBB4nTkCvm7vFrTzS4g	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+890	No	514382-034385	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+55	Yes	10003752-CZW8vMFx0kST6arJWb8DbA	Not Hispanic or Latino	Black or African American	Female	"CR, DX"	TRUE	FALSE	TRUE	FALSE
+57	No	419639-003462	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	10000364-1536954	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+70	Yes	10000364-909474	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	10022779-NupK1H1Nf0GJmX6BZ3nBkg	Hispanic or Latino	Not Reported	Male	CR	TRUE	FALSE	FALSE	FALSE
+82	No	10008204-Ql2CJTqwPEGDgfOGZKCAcQ	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+85	No	419639-010131	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+72	No	419639-000911	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+51	Yes	10003752-bM56YCLZU2ZAXTjn5VHPg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+74	No	514382-037706	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+78	Yes	514382-010222	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+85	Yes	419639-010904	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+68	Yes	10000364-135277	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+54	No	10008204-JDlK4rveZkdBBG6TdJWCQ	Not Hispanic or Latino	Asian	Male	CR	TRUE	FALSE	FALSE	FALSE
+16	Yes	10022779-MJjFKaAj0k7Yjz00MwA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+89	No	10008204-Xr754sYO5EmvlDCcFD4kg	Not Hispanic or Latino	White	Female	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+90	No	10003752-lslEAIJgaE2sSj115qLnfA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+43	Yes	10000364-1386150	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+66	No	419639-008743	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	Yes	514382-013334	Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+81	Yes	10003752-GbBwN8Nck0ednXTexEpRGQ	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+61	Yes	10003752-2BEpPsuYn0ab7f81bvDkA	Hispanic or Latino	Black or African American	Male	"CR, CT"	TRUE	TRUE	FALSE	FALSE
+59	No	514382-018084	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	No	514382-037685	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+48	No	10000364-1310302	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+3	No	10003752-TwfH8SGjUmvdMWMAi81Yw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+82	Yes	10003752-Bqg5ydinhkG71Pg7E992Eg	Not Hispanic or Latino	Black or African American	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+31	Yes	10008204-bX1SmvtFU6qWIXxWqmOYw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+35	Yes	514382-010254	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+23	Yes	10000364-1560684	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+69	Yes	514382-000324	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	10000364-1259380	Not Hispanic or Latino	White	Female	MR	FALSE	FALSE	FALSE	TRUE
+54	Yes	514382-009372	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+45	No	10008204-k2Aa7iWOSESs0cfsJcZvA	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+74	No	514382-039893	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+51	No	514382-034637	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	No	514382-016333	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+83	Yes	10000364-979114	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+70	Yes	10000364-5910778	Not Hispanic or Latino	White	Male	MR	FALSE	FALSE	FALSE	TRUE
+43	Yes	10022779-Z7ykbwwdm0y7WlqVAs8mQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+63	Yes	10000364-946840	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+83	Yes	514382-005842	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+74	No	419639-002759	Not Hispanic or Latino	White	Male	"CR,DX"	TRUE	FALSE	TRUE	FALSE
+62	Yes	514382-008257	Not Hispanic or Latino	Black or African American	Male	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+78	Yes	10003752-ZC2DCXFY0UpPCioKdcLQ	Not Hispanic or Latino	Black or African American	Male	"DX,CR"	TRUE	FALSE	TRUE	FALSE
+67	No	514382-016186	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	10022779-SRJB7C4ToUWsja6qK0BkuQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+36	Yes	419639-010389	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+65	Yes	514382-008407	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+73	No	514382-036493	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+77	No	514382-016718	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+29	No	419639-000775	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+37	Yes	514382-001752	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+42	No	514382-038821	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+84	Yes	514382-011566	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+56	Yes	514382-005107	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+88	No	419639-002652	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+90	No	10008204-x0HZdVGELUjdJhlqT2NwQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+59	No	419639-012215	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+48	No	10022779-GfDHKc1mskWusQvrFXYtw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+90	No	10008204-dgBnhQjWkUlwzTkENEQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+40	Yes	10022779-4sMsOozijUmeVTLJKaj0Dw	Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+52	Yes	514382-000259	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+76	Yes	10000364-6482135	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+82	Yes	419639-006191	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+47	Yes	514382-006140	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+76	Yes	10022779-jGMNAQqXO0OqTTEJG3Jg	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+49	No	514382-036424	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	10000364-743075	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+75	No	514382-039587	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+58	Yes	514382-014048	Not Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+54	No	419639-012109	Not Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+49	Yes	514382-004882	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+61	Yes	419639-010753	Not Hispanic or Latino	Not Reported	Male	"CR, DX, CT"	TRUE	TRUE	TRUE	FALSE
+75	No	514382-015976	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+66	No	514382-038582	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+86	No	419639-007458	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+34	No	419639-011051	Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+59	Yes	514382-006790	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	10008204-W1N4M7YwEe1xcPtA2h8BQ	Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+55	No	10022779-McfxkCeFoEqkVfbvf8vSUg	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+41	No	419639-012321	Not Hispanic or Latino	Not Reported	Male	CT	FALSE	TRUE	FALSE	FALSE
+82	Yes	10003752-M5CDsSG6VUGdGvXh8VAmdw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+44	Yes	419639-001021	Not Hispanic or Latino	Black or African American	Male	CT	FALSE	TRUE	FALSE	FALSE
+59	No	514382-014743	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+72	No	10003752-eoiFd1QQERQdSdclvKzw	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+68	Yes	10022779-KPkahTjcxkOfFlAp3JpwvA	Hispanic or Latino	Not Reported	Female	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+49	Yes	419639-012366	Hispanic or Latino	Not Reported	Female	"DX,CT,CR"	TRUE	TRUE	TRUE	FALSE
+63	Yes	10003752-DZcPZSmrlEqRNjsO5uK9AA	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+38	Yes	10022779-4kvaQKt0wU68ZTXPd0FjbA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+58	No	419639-006651	Hispanic or Latino	Not Reported	Male	"CR,DX,CT"	TRUE	TRUE	TRUE	FALSE
+69	Yes	514382-006792	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+70	No	514382-038282	Not Hispanic or Latino	Asian	Male	DX	FALSE	FALSE	TRUE	FALSE
+57	No	514382-017259	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	514382-011549	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+25	No	10008204-zCDe7aBIR0iii8zVTn3mVQ	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+31	Yes	419639-008221	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+63	Yes	10000364-792556	Not Hispanic or Latino	White	Male	CT	FALSE	TRUE	FALSE	FALSE
+5	No	10000364-2732367	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+78	No	514382-033864	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+41	Yes	10022779-wwPtvPGsnU2p8kzg2WTL2g	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+29	No	514382-039659	Not Hispanic or Latino	White	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+30	No	514382-039550	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+43	Yes	514382-012774	Not Hispanic or Latino	Not Reported	Female	CR	TRUE	FALSE	FALSE	FALSE
+44	Yes	10022779-EHRtdudikyaujzu1dgE6Q	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+33	No	419639-003015	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+36	Yes	514382-002326	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+59	Yes	10000364-1485193	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+62	No	514382-014998	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+18	No	419639-003723	Hispanic or Latino	Not Reported	Female	DX	FALSE	FALSE	TRUE	FALSE
+46	Yes	10000364-5478699	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	514382-008329	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+50	No	514382-034600	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+82	No	10008204-YcZuOAmEEa4lu8338Jm2Q	Not Hispanic or Latino	White	Male	"CT,CR"	TRUE	TRUE	FALSE	FALSE
+45	Yes	10022779-yirlVuipsUOjZZWpVP6Hw	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+68	No	10008204-t7Em8QQ5d0awrlAEg3Uw3g	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+48	Yes	10022779-PUav4J0Og0WUoLLbTiJUvA	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+20	No	10003752-pdrTNtSALke46hQYXTYNCg	Not Hispanic or Latino	White	Male	"DX,CR,CT"	TRUE	TRUE	TRUE	FALSE
+35	Yes	10022779-HoyZJd720SuBkJOjaTMkQ	Not Hispanic or Latino	Black or African American	Male	CR	TRUE	FALSE	FALSE	FALSE
+73	No	419639-011530	Not Hispanic or Latino	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+38	No	419639-000190	Not Hispanic or Latino	Black or African American	Female	CR	TRUE	FALSE	FALSE	FALSE
+28	Yes	514382-002431	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+74	Yes	419639-001975	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+51	No	419639-010842	Not Hispanic or Latino	Not Reported	Male	"DX, CT, CR"	TRUE	TRUE	TRUE	FALSE
+42	Yes	10000364-1581056	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+60	Yes	10000364-4950446	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+36	No	10000364-2404388	Not Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+73	Yes	514382-000682	Not Hispanic or Latino	Black or African American	Female	DX	FALSE	FALSE	TRUE	FALSE
+89	Yes	514382-002746	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+38	Yes	514382-014117	Not Hispanic or Latino	White	Female	CT	FALSE	TRUE	FALSE	FALSE
+58	Yes	514382-007522	Not Reported	Not Reported	Male	DX	FALSE	FALSE	TRUE	FALSE
+54	Yes	514382-008039	Hispanic or Latino	White	Male	DX	FALSE	FALSE	TRUE	FALSE
+67	No	419639-003630	Not Hispanic or Latino	Asian	Female	DX	FALSE	FALSE	TRUE	FALSE
+38	No	419639-002322	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+28	Yes	514382-006791	Not Hispanic or Latino	Black or African American	Male	DX	FALSE	FALSE	TRUE	FALSE
+71	Yes	514382-005737	Not Hispanic or Latino	Asian	Female	"CT,DX"	FALSE	TRUE	TRUE	FALSE
+58	No	514382-039569	Not Hispanic or Latino	Black or African American	Female	CT	FALSE	TRUE	FALSE	FALSE
+86	Yes	10000364-1915225	Not Hispanic or Latino	White	Male	"CR,CT"	TRUE	TRUE	FALSE	FALSE
+72	No	514382-038556	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+73	No	10000364-1001096	Not Hispanic or Latino	White	Female	CR	TRUE	FALSE	FALSE	FALSE
+80	Yes	419639-008076	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE
+55	Yes	10003752-zdcN7jSKcEisfGGt5IA8yg	Not Hispanic or Latino	White	Male	CR	TRUE	FALSE	FALSE	FALSE
+22	No	514382-038189	Not Hispanic or Latino	White	Female	DX	FALSE	FALSE	TRUE	FALSE

--- a/sampling_gui.py
+++ b/sampling_gui.py
@@ -4,9 +4,9 @@
 #through the Advanced Research Projects Agency for Health (ARPA-H).
 
 from PySide6.QtWidgets import (
-    QApplication, QWidget, QVBoxLayout, QLabel, QLineEdit, QPushButton, QProgressDialog,
+    QApplication, QLabel, QLineEdit, QPushButton, QProgressDialog,
     QFileDialog, QTableView, QMessageBox, QFormLayout, QHBoxLayout, QDialog, QCheckBox, QDialogButtonBox,
-    QVBoxLayout, QSpinBox, QDoubleSpinBox, QButtonGroup, QGridLayout, QScrollArea, QAbstractScrollArea, QWidget
+    QVBoxLayout, QDoubleSpinBox, QButtonGroup, QGridLayout, QScrollArea, QAbstractScrollArea, QWidget
 )
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QStandardItemModel, QStandardItem, QColor

--- a/stratified_sampling.py
+++ b/stratified_sampling.py
@@ -72,62 +72,66 @@ def check_for_duplicates(df_in: pd.DataFrame, uid_col: str) -> bool:
     return dupes.any()
 
 
-def stratified_sampling(data_in: pd.DataFrame, sampling_data: SamplingData, view_stats=False) -> pd.DataFrame:
+def stratified_sampling_old(data_in: pd.DataFrame,
+                        sampling_data: SamplingData,
+                        *,
+                        view_stats=False,
+                        bin_numeric_cols=True,
+                        random_seed=None) -> pd.DataFrame:
     """
-    Perform stratified sampling on a DataFrame.
-
-    Parameters:
-    - data (pandas.DataFrame): The DataFrame to be sampled.
-    - sampling_data (SamplingData): The sampling configuration.
-    - view_stats (bool): Whether to view the statistics of the sampling.
-
-    Returns:
-    - pandas.DataFrame: The sampled DataFrame.
+    Faster stratified sampling using group indices instead of repeated boolean indexing.
     """
-    numeric_cols = sampling_data.numeric_cols
-    """ 
-    # I don't think this is necessary anymore
-    if len(sampling_data.numeric_cols) == 0:
-        numeric_cols = {'age_at_index':
-                            {'bins': None,
-                             'labels': None}}
-    """
+    if random_seed is not None:
+        np.random.seed(random_seed)
 
     uid_col = sampling_data.uid_col
-    cols = sampling_data.features
+    cols = list(sampling_data.features)
 
     data_in[uid_col] = data_in[uid_col].astype(str)
 
     # Check for duplicates - If warning presents, go to merge batch
+    # OPTIONAL - DISABLE FOR BOOTSTRAPPING
     check_for_duplicates(data_in, uid_col)
 
-    # Convert numeric columns to numeric type and non-numeric columns to string type
-    for col_name in cols:
-        if col_name in numeric_cols:
-            data_in[col_name] = pd.to_numeric(data_in[col_name], errors='coerce')
+    # Bin numeric columns (creates cut columns)
+    if bin_numeric_cols:
+        if len(sampling_data.numeric_cols) == 0:
+            numeric_cols = {'Age at Index':
+                                {'raw column': 'age_at_index',
+                                 'bins': [0, 18, 50, 65, 1000],
+                                 'labels': ['0-17', "18-49", '50-64', '65+']}}
         else:
-            data_in[col_name] = data_in[col_name].astype(str)
+            numeric_cols = sampling_data.numeric_cols
+
+        # Convert types
+        for col_name in cols:
+            if col_name in numeric_cols:
+                raw_col_name = numeric_cols[col_name].get('raw column', col_name)
+                data_in[raw_col_name] = pd.to_numeric(data_in[raw_col_name], errors='coerce')
+            else:
+                data_in[col_name] = data_in[col_name].astype(str)
+
+        # cut_suffix = "_CUT" if len(numeric_cols) > 0 else ""
+        for col_name, bin_info in numeric_cols.items():
+            data_in = bin_dataframe_column(data_in,
+                                           column_name=bin_info.get('raw column', col_name),
+                                           cut_column_name=col_name,
+                                           bins=bin_info['bins'],
+                                           labels=bin_info['labels'])
+
+        # Determine grouping column names (use cut columns for numeric cols)
+        #group_cols = [(col + cut_suffix) if col in numeric_cols else col for col in cols]
+    #else:
+        #group_cols = cols
 
     # Copy the original data to a new dataframe
     final_table = copy.copy(data_in)
-
-    # Separate numeric groups into categories based on bin cutoff values
-    cut_suffix = "_CUT" if len(numeric_cols) > 0 else ""
-    for col_name, bin_info in numeric_cols.items():
-        data_in = bin_dataframe_column(data_in,
-                                       column_name=col_name,
-                                       cut_column_name=col_name + cut_suffix,
-                                       bins=bin_info['bins'],
-                                       labels=bin_info['labels'])
-        # We can use this to check the distribution of the binned column
-        # print(data[col_name + cut_suffix].value_counts(dropna=False))
 
     ## Stratified sampling process
 
     # Gather stats using a dictionary comprehension
     stats_dict = {
-        (f"{col_name}{cut_suffix}" if col_name in numeric_cols else col_name): group_counts(data_in,
-         f"{col_name}{cut_suffix}" if col_name in numeric_cols else col_name)
+        col_name: group_counts(data_in, col_name)
         for col_name in cols
     }
 
@@ -146,8 +150,7 @@ def stratified_sampling(data_in: pd.DataFrame, sampling_data: SamplingData, view
         # Filter the data based on the current combination of variable selections
         temp_df = data_in
         for j, col_name in enumerate(cols):
-            filter_col = col_name + cut_suffix if col_name in numeric_cols else col_name
-            temp_df = temp_df.loc[temp_df[filter_col] == var_selections[j]]
+            temp_df = temp_df.loc[temp_df[col_name] == var_selections[j]]
 
         if not temp_df.empty:
             total_fraction = sum(sampling_data.datasets.values())
@@ -173,13 +176,13 @@ def stratified_sampling(data_in: pd.DataFrame, sampling_data: SamplingData, view
             while start_index < len(temp_df_shuffled):
                 total_remainder = sum([v['remainder'] for v in dataset_split_dict.values()])
                 single_choice = np.random.choice(
-                                     list(dataset_split_dict.keys()),
-                                     p=[v['remainder']/total_remainder for v in dataset_split_dict.values()]
-                                     )
-                final_table.loc[final_table[uid_col] == temp_df_shuffled.iloc[start_index][uid_col], sampling_data.dataset_column] = single_choice
+                    list(dataset_split_dict.keys()),
+                    p=[v['remainder'] / total_remainder for v in dataset_split_dict.values()]
+                )
+                final_table.loc[final_table[uid_col] == temp_df_shuffled.iloc[start_index][
+                    uid_col], sampling_data.dataset_column] = single_choice
                 dataset_split_dict.pop(single_choice)
                 start_index += 1
-
 
     # print('Sampling complete. Saving Results...')
     # print(FinalTable[sampling_data.dataset_column].value_counts(dropna=False))
@@ -197,10 +200,40 @@ def stratified_sampling(data_in: pd.DataFrame, sampling_data: SamplingData, view
 
     return final_table
 
-def stratified_sampling_fast(data_in: pd.DataFrame, sampling_data, *, seed=None) -> pd.DataFrame:
+def stratified_sampling(data_in: pd.DataFrame, sampling_data, *, bin_numeric_cols=True, random_seed=None) -> pd.DataFrame:
     uid_col = sampling_data.uid_col
     cols = list(sampling_data.features)
     out = data_in.copy()  # or copy.copy(data_in)
+
+    # Check for duplicates - If warning presents, go to merge batch
+    # OPTIONAL - DISABLE FOR BOOTSTRAPPING
+    check_for_duplicates(data_in, uid_col)
+
+    # Bin numeric columns (creates cut columns)
+    if bin_numeric_cols:
+        if len(sampling_data.numeric_cols) == 0:
+            numeric_cols = {'Age at Index':
+                                {'raw column': 'age_at_index',
+                                 'bins': [0, 18, 50, 65, 1000],
+                                 'labels': ['0-17', "18-49", '50-64', '65+']}}
+        else:
+            numeric_cols = sampling_data.numeric_cols
+
+        # Convert types
+        for col_name in cols:
+            if col_name in numeric_cols:
+                raw_col_name = numeric_cols[col_name].get('raw column', col_name)
+                data_in[raw_col_name] = pd.to_numeric(data_in[raw_col_name], errors='coerce')
+            else:
+                data_in[col_name] = data_in[col_name].astype(str)
+
+        # cut_suffix = "_CUT" if len(numeric_cols) > 0 else ""
+        for col_name, bin_info in numeric_cols.items():
+            data_in = bin_dataframe_column(data_in,
+                                           column_name=bin_info.get('raw column', col_name),
+                                           cut_column_name=col_name,
+                                           bins=bin_info['bins'],
+                                           labels=bin_info['labels'])
 
     # Ensure target column exists
     if sampling_data.dataset_column not in out.columns:
@@ -223,7 +256,7 @@ def stratified_sampling_fast(data_in: pd.DataFrame, sampling_data, *, seed=None)
     # Work in a numpy array for fast assignment
     assigned = out[sampling_data.dataset_column].to_numpy(dtype=object)
 
-    rng = np.random.default_rng(seed)
+    rng = np.random.default_rng(random_seed)
 
     for _, grp in grouped:
         idx = grp.index.to_numpy()

--- a/stratified_sampling.py
+++ b/stratified_sampling.py
@@ -197,6 +197,74 @@ def stratified_sampling(data_in: pd.DataFrame, sampling_data: SamplingData, view
 
     return final_table
 
+def stratified_sampling_fast(data_in: pd.DataFrame, sampling_data, *, seed=None) -> pd.DataFrame:
+    uid_col = sampling_data.uid_col
+    cols = list(sampling_data.features)
+    out = data_in.copy()  # or copy.copy(data_in)
+
+    # Ensure target column exists
+    if sampling_data.dataset_column not in out.columns:
+        out[sampling_data.dataset_column] = ""
+
+    # Precompute split weights
+    datasets = list(sampling_data.datasets.keys())
+    datasets_arr = np.array(datasets, dtype=object)
+    weights = np.array([sampling_data.datasets[d] for d in datasets], dtype=float)
+    weights = weights / weights.sum()
+
+    # If possible, make group columns categorical to speed groupby
+    for c in cols:
+        if out[c].dtype == "object":
+            out[c] = out[c].astype("category")
+
+    # Group only on strata that exist
+    grouped = out.groupby(cols, sort=False, observed=True, dropna=False)
+
+    # Work in a numpy array for fast assignment
+    assigned = out[sampling_data.dataset_column].to_numpy(dtype=object)
+
+    rng = np.random.default_rng(seed)
+
+    for _, grp in grouped:
+        idx = grp.index.to_numpy()
+        m = idx.size
+        if m == 0:
+            continue
+
+        # Shuffle indices once
+        idx = rng.permutation(idx)
+
+        # Floor allocations
+        raw = weights * m
+        base = np.floor(raw).astype(int)
+        r = raw - base  # remainders
+
+        # Assign the base counts in one pass
+        start = 0
+        for d, k in zip(datasets, base):
+            if k:
+                assigned[idx[start:start+k]] = d
+                start += k
+
+        # Assign leftovers using remainder probabilities WITHOUT replacement
+        leftover = m - start
+        if leftover > 0:
+            if r.sum() == 0:
+                extra = rng.choice(datasets_arr, size=leftover, replace=False)
+            else:
+                # weighted without replacement
+                extra = rng.choice(datasets_arr, size=leftover, replace=False, p=r / r.sum())
+            assigned[idx[start:]] = extra
+
+    out[sampling_data.dataset_column] = assigned
+
+    # Handle unassigned (same idea as your code)
+    unassigned = (out[sampling_data.dataset_column] == "")
+    if unassigned.any():
+        out.loc[unassigned, sampling_data.dataset_column] = datasets[0]
+
+    return out
+
 def generate_output_filename(input_filename, *, extension: str = 'tsv', use_timestamp: bool = True,
                              prefix: str = 'COMPLETED_', suffix: str = '', timestamp_in_prefix: bool = False) -> str:
     """


### PR DESCRIPTION
This method produces nearly identical results after hundreds of thousands of runs. The primary difference is that this method creates a lookup table for which cell in the matrix each data row falls under, rather than doing a search over the entire dataframe for each possible cell.

This newer method is difficult for humans to read, so I've kept the original stratified sampling function as stratified_sampling_old() since it is conceptually identical, for future readers to understand the process.